### PR TITLE
CoreML export pipeline with stage harness

### DIFF
--- a/research/program.md
+++ b/research/program.md
@@ -1,0 +1,92 @@
+# kokoro-tts-swift CoreML Research
+
+This is an experiment to have the LLM optimize CoreML model export.
+
+## Setup
+
+To set up a new experiment, work with the user to:
+
+1. **Agree on a run tag**: propose a tag based on today's date (e.g. `mar14`). The branch `research/<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b research/<tag>` from current main.
+3. **Read the in-scope files**: Read these files for full context:
+   - `scripts/stage_harness.py` — fixed evaluation harness. Do not modify.
+   - `scripts/export_coreml.py` — the file you modify. Contains inlined `CustomSTFT` and `SineGen`, pipeline split modules, and export logic.
+   - `research/program.md` — this file.
+4. **Verify environment**: `.venv/bin/python scripts/stage_harness.py` should run all stages.
+5. **Initialize results.tsv**: Create `results.tsv` with just the header row. The baseline will be recorded after the first run.
+6. **Confirm and go**: Confirm setup looks good.
+
+Once you get confirmation, kick off the experimentation.
+
+## Experimentation
+
+Each experiment runs the stage harness, which traces, converts, and compares 11 targets across 3 test sentences. You launch it simply as: `.venv/bin/python scripts/stage_harness.py 2>&1 > run.log`
+
+**What you CAN do:**
+- Modify `scripts/export_coreml.py` — this is the only file you edit. Everything is fair game: CustomSTFT, SineGen, pipeline split modules, patching logic.
+
+**What you CANNOT do:**
+- Modify `scripts/stage_harness.py`. It is read-only. It contains the fixed evaluation, stage wrappers, and comparison logic.
+- Modify files in `.venv/`.
+- Install new packages or add dependencies.
+
+**The goal is simple: get the highest worst-case ANE Corr and lowest ANE latency.** The harness reports CPU Corr, ANE Corr, CPU Cold/Warm, ANE Cold/Warm for each stage. PASS if ANE Corr > 0.99. Pipeline stages (10, 11) test two-model CPU+ANE splits.
+
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude.
+
+**The first run**: Your very first run should always be to establish the baseline, so you will run the harness as is.
+
+## Output format
+
+The harness prints a results table like this:
+
+```
+Stage            Status    CPU Corr   Cold   Warm   ANE Corr   Cold   Warm
+----------------------------------------------------------------------------------------
+6_decoder        PASS        0.9961  371ms  335ms     0.9960 1398ms 1384ms
+10_gen_pipe      PASS        0.9961  353ms  327ms     0.9961  179ms  121ms
+11_dec_pipe      PASS        0.9961  378ms  337ms     0.9961  218ms  131ms
+```
+
+You can run a single stage for faster iteration:
+
+```
+.venv/bin/python scripts/stage_harness.py --stage 10
+.venv/bin/python scripts/stage_harness.py --stage 11
+```
+
+## Logging results
+
+When an experiment is done, log it to `results.tsv` (tab-separated, NOT comma-separated — commas break in descriptions).
+
+The TSV has a header row and 7 columns:
+
+```
+commit	stage	cpu_corr	ane_corr	cpu_warm_ms	ane_warm_ms	status	description
+```
+
+- One row per stage per experiment.
+- status: `keep`, `discard`, or `crash`
+- Run multiple times to verify — single-run results can be misleading due to phase-dependent variance.
+
+## The experiment loop
+
+The experiment runs on a dedicated branch (e.g. `research/mar14`).
+
+LOOP FOREVER:
+
+1. Look at the git state: the current branch/commit we're on
+2. Tune `scripts/export_coreml.py` with an experimental idea by directly hacking the code.
+3. git commit
+4. Run the experiment: `.venv/bin/python scripts/stage_harness.py > run.log 2>&1` (redirect everything — do NOT use tee or let output flood your context)
+5. Read out the results: `grep "WORST CASE" -A 20 run.log`
+6. If the grep output is empty, the run crashed. Run `tail -n 50 run.log` to read the Python stack trace and attempt a fix. If you can't get things to work after more than a few attempts, give up.
+7. Record the results in the tsv (NOTE: do not commit the results.tsv file, leave it untracked by git)
+8. If ANE Corr improved or ANE latency decreased without regression: keep.
+9. If worse: `git reset --hard HEAD~1`.
+
+The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. And you're advancing the branch so that you can iterate. If you feel like you're getting stuck in some way, you can rewind but you should probably do this very very sparingly (if ever).
+
+**Crashes**: If a run crashes, use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log "crash" as the status in the tsv, and move on.
+
+**NEVER STOP**: Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read the ANE reference guide (https://github.com/hollance/neural-engine), re-read the in-scope files for new angles, try combining previous near-misses, try more radical changes. The loop runs until the human interrupts you, period.

--- a/scripts/coreml_ops.py
+++ b/scripts/coreml_ops.py
@@ -1,0 +1,32 @@
+"""Shared coremltools op registrations for Kokoro TTS CoreML export."""
+
+from coremltools.converters.mil.frontend.torch.torch_op_registry import (
+    _TORCH_OPS_REGISTRY,
+    register_torch_op,
+)
+from coremltools.converters.mil import Builder as mb
+
+
+def register_missing_torch_ops():
+    """Register torch ops that coremltools doesn't handle natively."""
+    if "new_ones" not in _TORCH_OPS_REGISTRY:
+        @register_torch_op
+        def new_ones(context, node):
+            size = context[node.inputs[1]]
+            shape = mb.cast(x=size, dtype="int32", name=node.name + "_shape")
+            result = mb.fill(shape=shape, value=1.0, name=node.name)
+            context.add(result)
+
+    if "new_zeros" not in _TORCH_OPS_REGISTRY:
+        @register_torch_op
+        def new_zeros(context, node):
+            size = context[node.inputs[1]]
+            shape = mb.cast(x=size, dtype="int32", name=node.name + "_shape")
+            result = mb.fill(shape=shape, value=0.0, name=node.name)
+            context.add(result)
+
+    if "multiply" not in _TORCH_OPS_REGISTRY:
+        @register_torch_op
+        def multiply(context, node):
+            from coremltools.converters.mil.frontend.torch.ops import mul
+            mul(context, node)

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Export Kokoro-82M from PyTorch to CoreML models for kokoro-tts-swift.
+
+Creates two fixed-size CoreML models:
+  - kokoro_21_5s.mlmodelc  (max 124 tokens, ~5s audio)
+  - kokoro_24_10s.mlmodelc (max 242 tokens, ~10s audio)
+
+Usage:
+    .venv/bin/python scripts/export_coreml.py [--output-dir ./models_export]
+    .venv/bin/python scripts/export_coreml.py --verify
+    .venv/bin/python scripts/export_coreml.py --bucket kokoro_21_5s
+"""
+import argparse
+import os
+import subprocess
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import coremltools as ct
+from coreml_ops import register_missing_torch_ops
+
+# SineGen inlined from kokoro.istftnet with CoreML-compatible _f02sine.
+
+class SineGen(nn.Module):
+    def __init__(self, samp_rate, upsample_scale, harmonic_num=0,
+                 sine_amp=0.1, noise_std=0.003,
+                 voiced_threshold=0, flag_for_pulse=False):
+        super().__init__()
+        self.sine_amp = sine_amp
+        self.noise_std = noise_std
+        self.harmonic_num = harmonic_num
+        self.dim = self.harmonic_num + 1
+        self.sampling_rate = samp_rate
+        self.voiced_threshold = voiced_threshold
+        self.flag_for_pulse = flag_for_pulse
+        self.upsample_scale = upsample_scale
+
+    def _f02uv(self, f0):
+        uv = (f0 > self.voiced_threshold).type(torch.float32)
+        return uv
+
+    def _f02sine(self, f0_values):
+        # Instantaneous frequency as fraction of sample rate
+        # Fractional part of instantaneous frequency
+        val = f0_values / self.sampling_rate
+        rad_values = val - torch.floor(val)
+
+        # Random initial phase
+        if hasattr(self, '_external_phases') and self._external_phases is not None:
+            rand_ini = self._external_phases[:, :f0_values.shape[2]]
+        else:
+            rand_ini = torch.rand(f0_values.shape[0], f0_values.shape[2],
+                                  device=f0_values.device)
+
+        # Zero fundamental's phase offset
+        rand_ini = torch.cat([
+            torch.zeros(rand_ini.shape[0], 1, device=rand_ini.device),
+            rand_ini[:, 1:]
+        ], dim=1)
+
+        # Add phase offset to first time step
+        offset = F.pad(
+            rand_ini.unsqueeze(1),           # [B, 1, D]
+            (0, 0, 0, f0_values.shape[1] - 1)  # pad dim1: 0 left, L-1 right
+        )  # [B, L, D]
+        rad_values = rad_values + offset
+
+        if not self.flag_for_pulse:
+            K = int(self.upsample_scale)
+
+            # Downscale to frame rate
+            rad_t = rad_values.transpose(1, 2)                         # [B, D, L]
+            rad_down_t = F.avg_pool1d(rad_t, kernel_size=K, stride=K)  # [B, D, N]
+            rad_down = rad_down_t.transpose(1, 2)                      # [B, N, D]
+
+            # Cumulative phase at frame rate
+            phase_down = torch.cumsum(rad_down, dim=1)  # [B, N, D]
+
+            # Scale by 2πK and upscale with integer scale factor
+            phase_scaled = phase_down.transpose(1, 2) * (2.0 * torch.pi * K)
+            phase_up = F.interpolate(
+                phase_scaled,
+                scale_factor=float(K),
+                mode='linear',
+                align_corners=True
+            )  # [B, D, N*K]
+            phase = phase_up.transpose(1, 2)  # [B, N*K, D]
+
+            # Wrap phase to [0, 2π)
+            two_pi = 2.0 * torch.pi
+            phase = phase - two_pi * torch.floor(phase / two_pi)
+
+            sines = torch.sin(phase)
+
+        return sines
+
+    def forward(self, f0):
+        f0_buf = torch.zeros(f0.shape[0], f0.shape[1], self.dim, device=f0.device)
+        fn = torch.multiply(f0, torch.FloatTensor([[range(1, self.harmonic_num + 2)]]).to(f0.device))
+        sine_waves = self._f02sine(fn) * self.sine_amp
+        uv = self._f02uv(f0)
+        noise_amp = uv * self.noise_std + (1 - uv) * self.sine_amp / 3
+        noise = noise_amp * torch.randn_like(sine_waves)
+        sine_waves = sine_waves * uv + noise
+        return sine_waves, uv, noise
+
+# CustomSTFT inlined from kokoro.custom_stft.
+
+class CustomSTFT(nn.Module):
+    def __init__(self, filter_length=800, hop_length=200, win_length=800,
+                 window="hann", center=True, pad_mode="replicate"):
+        super().__init__()
+        self.filter_length = filter_length
+        self.hop_length = hop_length
+        self.win_length = win_length
+        self.n_fft = filter_length
+        self.center = center
+        self.pad_mode = pad_mode
+        self.freq_bins = self.n_fft // 2 + 1
+
+        assert window == 'hann', window
+        window_tensor = torch.hann_window(win_length, periodic=True, dtype=torch.float32)
+        if self.win_length < self.n_fft:
+            window_tensor = F.pad(window_tensor, (0, self.n_fft - self.win_length))
+        elif self.win_length > self.n_fft:
+            window_tensor = window_tensor[:self.n_fft]
+        self.register_buffer("window", window_tensor)
+
+        n = np.arange(self.n_fft)
+        k = np.arange(self.freq_bins)
+        angle = 2 * np.pi * np.outer(k, n) / self.n_fft
+        dft_real = np.cos(angle)
+        dft_imag = -np.sin(angle)
+
+        forward_window = window_tensor.numpy()
+        forward_real = dft_real * forward_window
+        forward_imag = dft_imag * forward_window
+
+        self.register_buffer("weight_forward_real",
+                             torch.from_numpy(forward_real).float().unsqueeze(1))
+        self.register_buffer("weight_forward_imag",
+                             torch.from_numpy(forward_imag).float().unsqueeze(1))
+
+        inv_scale = 1.0 / self.n_fft
+        angle_t = 2 * np.pi * np.outer(n, k) / self.n_fft
+        idft_cos = np.cos(angle_t).T
+        idft_sin = np.sin(angle_t).T
+        inv_window = window_tensor.numpy() * inv_scale
+
+        self.register_buffer("weight_backward_real",
+                             torch.from_numpy(idft_cos * inv_window).float().unsqueeze(1))
+        self.register_buffer("weight_backward_imag",
+                             torch.from_numpy(idft_sin * inv_window).float().unsqueeze(1))
+
+    def transform(self, waveform):
+        if self.center:
+            pad_len = self.n_fft // 2
+            waveform = F.pad(waveform, (pad_len, pad_len), mode=self.pad_mode)
+        x = waveform.unsqueeze(1)
+        real_out = F.conv1d(x, self.weight_forward_real, bias=None,
+                            stride=self.hop_length, padding=0)
+        imag_out = F.conv1d(x, self.weight_forward_imag, bias=None,
+                            stride=self.hop_length, padding=0)
+        magnitude = torch.sqrt(real_out**2 + imag_out**2 + 1e-14)
+        phase = torch.atan2(imag_out, real_out)
+        correction_mask = (imag_out == 0) & (real_out < 0)
+        phase[correction_mask] = torch.pi
+        return magnitude, phase
+
+    def inverse(self, magnitude, phase, length=None):
+        real_part = magnitude * torch.cos(phase)
+        imag_part = magnitude * torch.sin(phase)
+        real_rec = F.conv_transpose1d(real_part, self.weight_backward_real,
+                                      bias=None, stride=self.hop_length, padding=0)
+        imag_rec = F.conv_transpose1d(imag_part, self.weight_backward_imag,
+                                      bias=None, stride=self.hop_length, padding=0)
+        waveform = real_rec - imag_rec
+        if self.center:
+            pad_len = self.n_fft // 2
+            waveform = waveform[..., pad_len:-pad_len]
+        if length is not None:
+            waveform = waveform[..., :length]
+        return waveform
+
+    def forward(self, x):
+        mag, phase = self.transform(x)
+        return self.inverse(mag, phase, length=x.shape[-1])
+
+register_missing_torch_ops()
+
+
+# ---------------------------------------------------------------------------
+# Pipeline split modules
+# ---------------------------------------------------------------------------
+class GeneratorFrontEnd(nn.Module):
+    """SineGen + STFT transform -> har conditioning."""
+    def __init__(self, generator):
+        super().__init__()
+        self.f0_upsamp = generator.f0_upsamp
+        self.m_source = generator.m_source
+        self.stft = generator.stft
+
+    def forward(self, f0_curve):
+        f0 = self.f0_upsamp(f0_curve[:, None]).transpose(1, 2)
+        har_source, noi_source, uv = self.m_source(f0)
+        har_source = har_source.transpose(1, 2).squeeze(1)
+        har_spec, har_phase = self.stft.transform(har_source)
+        return torch.cat([har_spec, har_phase], dim=1)
+
+
+class GeneratorBackEnd(nn.Module):
+    """Upsampling cascade + inverse STFT -> audio.
+    Takes precomputed har conditioning."""
+    def __init__(self, generator):
+        super().__init__()
+        self.num_upsamples = generator.num_upsamples
+        self.num_kernels = generator.num_kernels
+        self.noise_convs = generator.noise_convs
+        self.noise_res = generator.noise_res
+        self.ups = generator.ups
+        self.resblocks = generator.resblocks
+        self.reflection_pad = generator.reflection_pad
+        self.conv_post = generator.conv_post
+        self.post_n_fft = generator.post_n_fft
+        self.stft = generator.stft
+
+    def forward(self, x, s, har):
+        for i in range(self.num_upsamples):
+            x = F.leaky_relu(x, negative_slope=0.1)
+            x_source = self.noise_convs[i](har)
+            x_source = self.noise_res[i](x_source, s)
+            x = self.ups[i](x)
+            if i == self.num_upsamples - 1:
+                x = self.reflection_pad(x)
+            x = x + x_source
+            xs = None
+            for j in range(self.num_kernels):
+                if xs is None:
+                    xs = self.resblocks[i * self.num_kernels + j](x, s)
+                else:
+                    xs += self.resblocks[i * self.num_kernels + j](x, s)
+            x = xs / self.num_kernels
+        x = F.leaky_relu(x)
+        x = self.conv_post(x)
+        spec = torch.exp(x[:, :self.post_n_fft // 2 + 1, :])
+        phase = torch.sin(x[:, self.post_n_fft // 2 + 1:, :])
+        return self.stft.inverse(spec, phase)
+
+
+class DecoderBackEnd(nn.Module):
+    """Full decoder with precomputed har conditioning.
+    Decoder preprocessing + GeneratorBackEnd."""
+    def __init__(self, decoder):
+        super().__init__()
+        self.F0_conv = decoder.F0_conv
+        self.N_conv = decoder.N_conv
+        self.encode = decoder.encode
+        self.decode = decoder.decode
+        self.asr_res = decoder.asr_res
+        self.gen_backend = GeneratorBackEnd(decoder.generator)
+
+    def forward(self, asr, F0_curve, N, s, har):
+        F0 = self.F0_conv(F0_curve.unsqueeze(1))
+        N_out = self.N_conv(N.unsqueeze(1))
+        x = torch.cat([asr, F0, N_out], axis=1)
+        x = self.encode(x, s)
+        asr_res = self.asr_res(asr)
+        res = True
+        for block in self.decode:
+            if res:
+                x = torch.cat([x, asr_res, F0, N_out], axis=1)
+            x = block(x, s)
+            if block.upsample_type != "none":
+                res = False
+        return self.gen_backend(x, s, har)
+
+
+# ---------------------------------------------------------------------------
+# Model config
+# ---------------------------------------------------------------------------
+BUCKETS = {
+    "kokoro_21_5s":  {"max_tokens": 124, "max_audio": 175_800},
+    "kokoro_24_10s": {"max_tokens": 242, "max_audio": 240_000},
+}
+
+SAMPLES_PER_FRAME = 600  # decoder upsample (2x) * generator (10*6*5=300)
+NUM_HARMONICS = 9        # fundamental + 8 overtones
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patches for CoreML compatibility
+# ---------------------------------------------------------------------------
+def patch_pack_padded_sequence():
+    """Replace pack_padded_sequence/pad_packed_sequence with no-ops.
+
+    CoreML cannot convert these ops. PyTorch audio quality is identical
+    without them (verified empirically).
+    """
+    nn.utils.rnn.pack_padded_sequence = lambda x, lengths, **kw: x
+    nn.utils.rnn.pad_packed_sequence = lambda x, **kw: (x, None)
+
+
+def patch_sinegen_for_export(model):
+    """Apply inlined SineGen to the model and return a phases helper.
+
+    The inlined SineGen class (above) has CoreML-compatible _f02sine built in.
+    This function applies it to the loaded model's SineGen instances via
+    class-level method replacement, and provides the set_phases helper.
+    """
+    from kokoro.istftnet import SineGen as OriginalSineGen
+
+    # Replace _f02sine on the original class
+    OriginalSineGen._f02sine = SineGen._f02sine
+
+    # Deterministic noise for reproducible comparisons
+    _orig_forward = OriginalSineGen.forward
+    def _deterministic_forward(self, f0):
+        _real_randn = torch.randn_like
+        torch.randn_like = torch.zeros_like
+        try:
+            return _orig_forward(self, f0)
+        finally:
+            torch.randn_like = _real_randn
+    OriginalSineGen.forward = _deterministic_forward
+
+    # Set external phases on all SineGen instances
+    def set_phases(module, phases):
+        for m in module.modules():
+            if isinstance(m, OriginalSineGen):
+                m._external_phases = torch.zeros_like(phases)
+
+    return set_phases
+
+
+# ---------------------------------------------------------------------------
+# Model loading
+# ---------------------------------------------------------------------------
+def load_kokoro_model():
+    from kokoro import KPipeline
+    from kokoro.istftnet import CustomSTFT
+
+    pipeline = KPipeline(lang_code="a")
+    model = pipeline.model
+    model.eval()
+
+    # Swap TorchSTFT → CustomSTFT (conv1d-based, no complex ops, CoreML-safe)
+    gen = model.decoder.generator
+    gen.stft = CustomSTFT(
+        filter_length=gen.stft.filter_length,
+        hop_length=gen.stft.hop_length,
+        win_length=gen.stft.win_length,
+    )
+
+    return pipeline, model
+
+
+# ---------------------------------------------------------------------------
+# Fixed-shape wrapper for export
+# ---------------------------------------------------------------------------
+class KokoroStaticWrapper(nn.Module):
+    """Fixed-shape wrapper for CoreML export.
+
+    Takes raw token IDs and produces audio. All intermediate tensors
+    use fixed maximum sizes determined by the bucket config.
+    """
+
+    def __init__(self, model, max_tokens, max_audio, set_phases_fn):
+        super().__init__()
+        self.max_tokens = max_tokens
+        self.max_audio = max_audio
+        self.max_frames = max_audio // SAMPLES_PER_FRAME
+        self.set_phases_fn = set_phases_fn
+
+        self.bert = model.bert
+        self.bert_encoder = model.bert_encoder
+        self.predictor = model.predictor
+        self.text_encoder = model.text_encoder
+        self.decoder = model.decoder
+
+    def forward(self, input_ids, attention_mask, ref_s, speed, random_phases):
+        """
+        Args:
+            input_ids:       [1, max_tokens] int32 — token IDs (0-padded)
+            attention_mask:  [1, max_tokens] int32 — 1=real, 0=padding
+            ref_s:           [1, 256] float32 — voice style embedding
+            speed:           [1] float32 — speed factor
+            random_phases:   [1, 9] float32 — harmonic phase offsets
+        Returns:
+            audio:           [1, 1, max_audio] float32 — waveform (silence-padded)
+            audio_length:    [1] int32 — number of valid audio samples
+            pred_dur:        [1, max_tokens] float32 — per-token durations
+        """
+        # Set external phases on all SineGen instances
+        self.set_phases_fn(self.decoder, random_phases)
+
+        input_lengths = attention_mask.sum(dim=1).long()
+        text_mask = (attention_mask == 0)  # True for padding positions
+
+        # BERT encoding
+        bert_dur = self.bert(input_ids, attention_mask=attention_mask)
+        d_en = self.bert_encoder(bert_dur).transpose(-1, -2)
+
+        s = ref_s[:, 128:]  # style for predictor
+
+        # Duration prediction
+        d = self.predictor.text_encoder(d_en, s, input_lengths, text_mask)
+        x, _ = self.predictor.lstm(d)
+        duration = self.predictor.duration_proj(x)
+        duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
+        pred_dur = torch.round(duration).clamp(min=1).long()
+
+        # Zero out padding token durations
+        pred_dur = pred_dur * attention_mask.long()
+
+        # Static alignment matrix using cumsum (avoids dynamic repeat_interleave)
+        cumsum = torch.cumsum(pred_dur, dim=-1)  # [1, max_tokens]
+        total_frames = cumsum[0, -1]
+
+        # Fixed-size frame indices (max_frames)
+        frame_indices = torch.arange(
+            self.max_frames, device=input_ids.device
+        ).unsqueeze(0)  # [1, max_frames]
+
+        starts = F.pad(cumsum[:, :-1], (1, 0))  # [1, max_tokens]
+
+        # Alignment: pred_aln_trg[b, t, f] = 1 iff frame f belongs to token t
+        pred_aln_trg = (
+            (frame_indices.unsqueeze(1) >= starts.unsqueeze(2)) &
+            (frame_indices.unsqueeze(1) < cumsum.unsqueeze(2))
+        ).float()  # [1, max_tokens, max_frames]
+
+        # Apply alignment to get frame-level features
+        en = d.transpose(-1, -2) @ pred_aln_trg  # [1, 640, max_frames]
+        F0_pred, N_pred = self.predictor.F0Ntrain(en, s)
+
+        t_en = self.text_encoder(input_ids, input_lengths, text_mask)
+        asr = t_en @ pred_aln_trg  # [1, 512, max_frames]
+
+        # Decode to audio (fixed output length = max_frames * SAMPLES_PER_FRAME)
+        audio = self.decoder(
+            asr, F0_pred, N_pred, ref_s[:, :128]
+        )  # [1, 1, max_audio]
+
+        # Audio length from predicted durations
+        audio_length = (total_frames * SAMPLES_PER_FRAME).int().unsqueeze(0)
+
+        return audio, audio_length, pred_dur.float()
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+def export_bucket(pipeline, model, set_phases_fn, bucket_name, bucket_config,
+                  output_dir, verify=False):
+    max_tokens = bucket_config["max_tokens"]
+    max_audio = bucket_config["max_audio"]
+
+    print(f"\nExporting {bucket_name} (max_tokens={max_tokens}, max_audio={max_audio})")
+
+    wrapper = KokoroStaticWrapper(model, max_tokens, max_audio, set_phases_fn)
+    wrapper.eval()
+
+    # Example inputs for tracing
+    example_ids = torch.zeros(1, max_tokens, dtype=torch.int64)
+    example_ids[0, :3] = torch.tensor([0, 50, 1])
+    example_mask = torch.zeros(1, max_tokens, dtype=torch.int64)
+    example_mask[0, :3] = 1
+    example_ref_s = torch.randn(1, 256)
+    example_speed = torch.tensor([1.0])
+    example_phases = torch.rand(1, NUM_HARMONICS) * 2 * torch.pi
+
+    print("  Tracing model...")
+    with torch.no_grad():
+        traced = torch.jit.trace(
+            wrapper,
+            (example_ids, example_mask, example_ref_s,
+             example_speed, example_phases),
+            check_trace=False,
+        )
+
+    print("  Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.TensorType(name="input_ids", shape=(1, max_tokens), dtype=np.int32),
+            ct.TensorType(name="attention_mask", shape=(1, max_tokens),
+                          dtype=np.int32),
+            ct.TensorType(name="ref_s", shape=(1, 256), dtype=np.float32),
+            ct.TensorType(name="speed", shape=(1,), dtype=np.float32),
+            ct.TensorType(name="random_phases", shape=(1, NUM_HARMONICS),
+                          dtype=np.float32),
+        ],
+        outputs=[
+            ct.TensorType(name="audio", dtype=np.float32),
+            ct.TensorType(name="audio_length_samples", dtype=np.int32),
+            ct.TensorType(name="pred_dur_clamped", dtype=np.float32),
+        ],
+        minimum_deployment_target=ct.target.macOS15,
+        compute_precision=ct.precision.FLOAT32,
+        convert_to="mlprogram",
+    )
+
+    mlpackage_path = os.path.join(output_dir, f"{bucket_name}.mlpackage")
+    mlmodel.save(mlpackage_path)
+    print(f"  Saved {mlpackage_path}")
+
+    print("  Compiling to .mlmodelc...")
+    compile_result = subprocess.run(
+        ["xcrun", "coremlcompiler", "compile", mlpackage_path, output_dir],
+        capture_output=True, text=True
+    )
+    compiled_path = os.path.join(output_dir, f"{bucket_name}.mlmodelc")
+    if compile_result.returncode == 0 and os.path.exists(compiled_path):
+        print(f"  Compiled: {compiled_path}")
+    else:
+        print(f"  Compilation failed: {compile_result.stderr[:200]}")
+
+    if verify:
+        verify_export(pipeline, model, set_phases_fn, mlmodel,
+                      bucket_name, max_tokens)
+
+    return mlmodel
+
+
+def verify_export(pipeline, pytorch_model, set_phases_fn, coreml_model,
+                  bucket_name, max_tokens):
+    print(f"\n  Verifying {bucket_name}...")
+
+    text = "Hello world, this is a test."
+    phonemes, _ = pipeline.g2p(text)
+    token_ids = pipeline.tokenize(phonemes)
+    if hasattr(token_ids, 'tolist'):
+        token_ids = token_ids.tolist()
+
+    seq_len = min(len(token_ids), max_tokens)
+    token_ids = token_ids[:seq_len]
+
+    voice_pack = pipeline.load_voice("af_heart")
+    ref_s_tensor = voice_pack[len(token_ids)]
+    if ref_s_tensor.dim() == 1:
+        ref_s_tensor = ref_s_tensor.unsqueeze(0)
+
+    # Fixed phases for deterministic comparison
+    phases = torch.rand(1, NUM_HARMONICS) * 2 * torch.pi
+
+    # Run PyTorch reference
+    set_phases_fn(pytorch_model.decoder, phases)
+    with torch.no_grad():
+        py_audio, py_dur = pytorch_model.forward_with_tokens(
+            torch.tensor([token_ids], dtype=torch.int64),
+            ref_s_tensor, 1.0,
+        )
+    py_audio_np = py_audio.numpy()
+
+    # Run CoreML
+    input_ids = np.zeros((1, max_tokens), dtype=np.int32)
+    input_ids[0, :seq_len] = token_ids
+    mask = np.zeros((1, max_tokens), dtype=np.int32)
+    mask[0, :seq_len] = 1
+
+    coreml_out = coreml_model.predict({
+        "input_ids": input_ids,
+        "attention_mask": mask,
+        "ref_s": ref_s_tensor.numpy().astype(np.float32),
+        "speed": np.array([1.0], dtype=np.float32),
+        "random_phases": phases.numpy().astype(np.float32),
+    })
+
+    coreml_audio = coreml_out["audio"].flatten()
+    coreml_len = int(coreml_out["audio_length_samples"].flatten()[0])
+    coreml_audio = coreml_audio[:coreml_len]
+
+    min_len = min(len(py_audio_np), len(coreml_audio))
+    if min_len == 0:
+        print("  ERROR: empty audio")
+        return
+
+    diff = py_audio_np[:min_len] - coreml_audio[:min_len]
+    mse = float(np.mean(diff ** 2))
+    max_diff = float(np.max(np.abs(diff)))
+    corr = float(np.corrcoef(py_audio_np[:min_len], coreml_audio[:min_len])[0, 1])
+
+    print(f"  PyTorch: {len(py_audio_np)} samples, "
+          f"CoreML: {len(coreml_audio)} samples")
+    print(f"  MSE: {mse:.8f}, Max diff: {max_diff:.6f}, Correlation: {corr:.6f}")
+
+    if corr > 0.99:
+        print(f"  PASS (correlation {corr:.4f})")
+    elif corr > 0.95:
+        print(f"  WARN (correlation {corr:.4f})")
+    else:
+        print(f"  FAIL (correlation {corr:.4f})")
+
+    # Save both for listening
+    import soundfile as sf
+    os.makedirs("verify_output", exist_ok=True)
+    sf.write(f"verify_output/{bucket_name}_pytorch.wav", py_audio_np, 24000)
+    sf.write(f"verify_output/{bucket_name}_coreml.wav", coreml_audio, 24000)
+    print(f"  Saved to verify_output/{bucket_name}_{{pytorch,coreml}}.wav")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="Export Kokoro-82M to CoreML")
+    parser.add_argument("--output-dir", default="./models_export")
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--bucket", choices=list(BUCKETS.keys()))
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    print("Applying CoreML compatibility patches...")
+    patch_pack_padded_sequence()
+
+    print("Loading Kokoro model...")
+    pipeline, model = load_kokoro_model()
+
+    print("Patching SineGen for CoreML...")
+    set_phases_fn = patch_sinegen_for_export(model)
+
+    buckets = {args.bucket: BUCKETS[args.bucket]} if args.bucket else BUCKETS
+    for name, config in buckets.items():
+        export_bucket(pipeline, model, set_phases_fn, name, config,
+                      args.output_dir, verify=args.verify)
+
+    print(f"\nDone. Models in {args.output_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stage_harness.py
+++ b/scripts/stage_harness.py
@@ -1,0 +1,1070 @@
+#!/usr/bin/env python3
+"""Stage-by-stage CoreML comparison harness for Kokoro TTS.
+
+Isolates each model stage into a standalone module, converts to CoreML,
+and compares PyTorch vs CoreML outputs. Stages don't cascade — each
+uses PyTorch-computed intermediates as input.
+
+Usage:
+    .venv/bin/python scripts/stage_harness.py
+    .venv/bin/python scripts/stage_harness.py --stage 1    # run single stage
+    .venv/bin/python scripts/stage_harness.py --json        # machine-readable output
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# ---------------------------------------------------------------------------
+# Patches (must happen before model load)
+# ---------------------------------------------------------------------------
+nn.utils.rnn.pack_padded_sequence = lambda x, lengths, **kw: x
+nn.utils.rnn.pad_packed_sequence = lambda x, **kw: (x, None)
+
+import coremltools as ct
+from coreml_ops import register_missing_torch_ops
+
+register_missing_torch_ops()
+
+sys.path.insert(0, os.path.dirname(__file__))
+from export_coreml import patch_sinegen_for_export, SAMPLES_PER_FRAME, SineGen
+from export_coreml import GeneratorFrontEnd, GeneratorBackEnd, DecoderBackEnd
+
+# ---------------------------------------------------------------------------
+# Stage wrapper modules
+# ---------------------------------------------------------------------------
+
+class Stage1_BERT(nn.Module):
+    """BERT + BertEncoder: input_ids → d_en"""
+    def __init__(self, model):
+        super().__init__()
+        self.bert = model.bert
+        self.bert_encoder = model.bert_encoder
+
+    def forward(self, input_ids, attention_mask):
+        bert_dur = self.bert(input_ids, attention_mask=attention_mask)
+        d_en = self.bert_encoder(bert_dur).transpose(-1, -2)
+        return d_en
+
+
+class Stage2_Duration(nn.Module):
+    """Duration prediction: d_en, style → pred_dur"""
+    def __init__(self, model):
+        super().__init__()
+        self.text_encoder = model.predictor.text_encoder
+        self.lstm = model.predictor.lstm
+        self.duration_proj = model.predictor.duration_proj
+
+    def forward(self, d_en, s, input_lengths, text_mask, speed, attention_mask):
+        d = self.text_encoder(d_en, s, input_lengths, text_mask)
+        x, _ = self.lstm(d)
+        duration = self.duration_proj(x)
+        duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
+        pred_dur = torch.round(duration).clamp(min=1).long()
+        pred_dur = pred_dur * attention_mask.long()
+        return pred_dur, d
+
+
+class Stage3_Alignment(nn.Module):
+    """Alignment matrix: pred_dur → pred_aln_trg (pure math)"""
+    def __init__(self, max_frames):
+        super().__init__()
+        self.max_frames = max_frames
+
+    def forward(self, pred_dur):
+        cumsum = torch.cumsum(pred_dur, dim=-1)
+        frame_indices = torch.arange(
+            self.max_frames, device=pred_dur.device
+        ).unsqueeze(0)
+        starts = F.pad(cumsum[:, :-1], (1, 0))
+        pred_aln_trg = (
+            (frame_indices.unsqueeze(1) >= starts.unsqueeze(2)) &
+            (frame_indices.unsqueeze(1) < cumsum.unsqueeze(2))
+        ).float()
+        # total_frames derivable from pred_dur: cumsum[0, -1]
+        # Return as 1D tensor to avoid scalar output ordering issues in CoreML
+        total_frames = cumsum[:, -1:].float()  # [1, 1]
+        return pred_aln_trg, total_frames
+
+
+class Stage4_F0N(nn.Module):
+    """F0/N prediction: d, pred_aln_trg, style → F0, N"""
+    def __init__(self, model):
+        super().__init__()
+        self.F0Ntrain = model.predictor.F0Ntrain
+        # Bind the shared LSTM and F0/N modules
+        self.shared = model.predictor.shared
+        self.F0_blocks = model.predictor.F0
+        self.N_blocks = model.predictor.N
+        self.F0_proj = model.predictor.F0_proj
+        self.N_proj = model.predictor.N_proj
+
+    def forward(self, d, pred_aln_trg, s):
+        en = d.transpose(-1, -2) @ pred_aln_trg
+        F0_pred, N_pred = self.F0Ntrain(en, s)
+        return F0_pred, N_pred
+
+
+class Stage5_TextEncoder(nn.Module):
+    """Text encoding + alignment: input_ids → asr"""
+    def __init__(self, model):
+        super().__init__()
+        self.text_encoder = model.text_encoder
+
+    def forward(self, input_ids, input_lengths, text_mask, pred_aln_trg):
+        t_en = self.text_encoder(input_ids, input_lengths, text_mask)
+        asr = t_en @ pred_aln_trg
+        return asr
+
+
+class Stage6_Decoder(nn.Module):
+    """Full decoder: asr, F0, N, style → audio"""
+    def __init__(self, model):
+        super().__init__()
+        self.decoder = model.decoder
+
+    def forward(self, asr, F0_pred, N_pred, s_content):
+        audio = self.decoder(asr, F0_pred, N_pred, s_content)
+        return audio
+
+
+class Stage7_Generator(nn.Module):
+    """Generator only (inside decoder): x, style, F0_curve → audio"""
+    def __init__(self, model):
+        super().__init__()
+        self.generator = model.decoder.generator
+
+    def forward(self, x, s, f0_curve):
+        return self.generator(x, s, f0_curve)
+
+
+class SplitA_Predictor(nn.Module):
+    """Split model A: BERT + Duration + Alignment + F0/N + TextEncoder (stages 1-5)."""
+    def __init__(self, model, max_frames):
+        super().__init__()
+        self.bert = model.bert
+        self.bert_encoder = model.bert_encoder
+        self.predictor = model.predictor
+        self.text_encoder = model.text_encoder
+        self.max_frames = max_frames
+
+    def forward(self, input_ids, attention_mask, ref_s, speed):
+        input_lengths = attention_mask.sum(dim=1).long()
+        text_mask = (attention_mask == 0)
+
+        bert_dur = self.bert(input_ids, attention_mask=attention_mask)
+        d_en = self.bert_encoder(bert_dur).transpose(-1, -2)
+
+        s = ref_s[:, 128:]
+
+        d = self.predictor.text_encoder(d_en, s, input_lengths, text_mask)
+        x, _ = self.predictor.lstm(d)
+        duration = self.predictor.duration_proj(x)
+        duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
+        pred_dur = torch.round(duration).clamp(min=1).long()
+        pred_dur = pred_dur * attention_mask.long()
+
+        cumsum = torch.cumsum(pred_dur, dim=-1)
+        total_frames = cumsum[:, -1:]  # [1, 1]
+        frame_indices = torch.arange(
+            self.max_frames, device=input_ids.device).unsqueeze(0)
+        starts = F.pad(cumsum[:, :-1], (1, 0))
+        pred_aln_trg = (
+            (frame_indices.unsqueeze(1) >= starts.unsqueeze(2)) &
+            (frame_indices.unsqueeze(1) < cumsum.unsqueeze(2))
+        ).float()
+
+        en = d.transpose(-1, -2) @ pred_aln_trg
+        F0_pred, N_pred = self.predictor.F0Ntrain(en, s)
+
+        t_en = self.text_encoder(input_ids, input_lengths, text_mask)
+        asr = t_en @ pred_aln_trg
+
+        return asr, F0_pred, N_pred, total_frames
+
+
+class SplitB_Decoder(nn.Module):
+    """Split model B: Decoder (stage 6)."""
+    def __init__(self, model):
+        super().__init__()
+        self.decoder = model.decoder
+
+    def forward(self, asr, F0_pred, N_pred, s_content):
+        return self.decoder(asr, F0_pred, N_pred, s_content)
+
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+def compare_tensors(py_out, coreml_out, active_length=None):
+    """Compare PyTorch and CoreML output tensors.
+
+    If active_length is set, compare only the first active_length samples
+    (ignores garbage tail from fixed-size audio output).
+    """
+    py_np = py_out.numpy().flatten() if isinstance(py_out, torch.Tensor) else py_out.flatten()
+    cml_np = coreml_out.flatten()
+    ml = min(len(py_np), len(cml_np))
+    if active_length is not None:
+        ml = min(ml, active_length)
+    if ml == 0:
+        return {"corr": 0, "mse": 0, "max_diff": 0, "shape_match": False}
+
+    py_np = py_np[:ml].astype(np.float64)
+    cml_np = cml_np[:ml].astype(np.float64)
+
+    mse = float(np.mean((py_np - cml_np) ** 2))
+    max_diff = float(np.max(np.abs(py_np - cml_np)))
+
+    if np.std(py_np) < 1e-10 or np.std(cml_np) < 1e-10:
+        corr = 1.0 if mse < 1e-10 else 0.0
+    else:
+        corr = float(np.corrcoef(py_np, cml_np)[0, 1])
+
+    return {"corr": corr, "mse": mse, "max_diff": max_diff, "len": ml}
+
+
+def test_stage(name, module, example_inputs, input_specs, output_names=None, active_length=None):
+    """Trace, convert, and compare a single stage.
+
+    Returns dict with metrics or error info.
+    """
+    result = {"name": name, "status": "unknown"}
+    module.eval()
+
+    # PyTorch forward
+    try:
+        with torch.no_grad():
+            py_outputs = module(*example_inputs)
+        if not isinstance(py_outputs, tuple):
+            py_outputs = (py_outputs,)
+        result["py_shapes"] = [list(o.shape) for o in py_outputs]
+    except Exception as e:
+        result["status"] = "pytorch_error"
+        result["error"] = str(e)
+        return result, None
+
+    # Trace
+    try:
+        t0 = time.time()
+        with torch.no_grad():
+            traced = torch.jit.trace(module, example_inputs, check_trace=False)
+        result["trace_time"] = round(time.time() - t0, 2)
+    except Exception as e:
+        result["status"] = "trace_error"
+        result["error"] = str(e)
+        return result, py_outputs
+
+    # Convert
+    try:
+        t0 = time.time()
+        mlmodel = ct.convert(
+            traced,
+            inputs=input_specs,
+            minimum_deployment_target=ct.target.macOS15,
+            compute_precision=ct.precision.FLOAT32,
+            convert_to="mlprogram",
+        )
+        result["convert_time"] = round(time.time() - t0, 2)
+    except Exception as e:
+        result["status"] = "convert_error"
+        result["error"] = str(e)
+        return result, py_outputs
+
+    # Build feed dict
+    feed = {}
+    for spec, tensor in zip(input_specs, example_inputs):
+        feed[spec.name] = tensor.numpy().astype(np.float32) \
+            if tensor.dtype in (torch.float32, torch.float64) \
+            else tensor.numpy().astype(np.int32)
+
+    # Save to temp file so we can reload with different compute units
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = os.path.join(tmpdir, "model.mlpackage")
+        mlmodel.save(tmp_path)
+
+        WARMUP_RUNS = 2
+        TIMED_RUNS = 3
+
+        # Run on ALL (ANE-eligible)
+        ane_out = None
+        try:
+            ml_all = ct.models.MLModel(tmp_path, compute_units=ct.ComputeUnit.ALL)
+            # Cold run
+            t0 = time.time()
+            ane_out = ml_all.predict(feed)
+            result["predict_time_ane_cold"] = round(time.time() - t0, 3)
+            # Warm up
+            for _ in range(WARMUP_RUNS):
+                ml_all.predict(feed)
+            # Timed warm runs
+            t0 = time.time()
+            for _ in range(TIMED_RUNS):
+                ane_out = ml_all.predict(feed)
+            result["predict_time_ane"] = round((time.time() - t0) / TIMED_RUNS, 3)
+            result["ane_ok"] = True
+        except Exception:
+            result["ane_ok"] = False
+
+        # Run on CPU_ONLY
+        cpu_out = None
+        try:
+            ml_cpu = ct.models.MLModel(tmp_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+            # Cold run
+            t0 = time.time()
+            cpu_out = ml_cpu.predict(feed)
+            result["predict_time_cpu_cold"] = round(time.time() - t0, 3)
+            # Warm up
+            for _ in range(WARMUP_RUNS):
+                ml_cpu.predict(feed)
+            # Timed warm runs
+            t0 = time.time()
+            for _ in range(TIMED_RUNS):
+                cpu_out = ml_cpu.predict(feed)
+            result["predict_time_cpu"] = round((time.time() - t0) / TIMED_RUNS, 3)
+            result["cpu_ok"] = True
+        except Exception:
+            result["cpu_ok"] = False
+
+    if ane_out is None and cpu_out is None:
+        result["status"] = "predict_error"
+        result["error"] = "both ANE and CPU failed"
+        return result, py_outputs
+
+    def _match_and_compare(py_outputs, coreml_out, output_names, active_length=None):
+        """Match CoreML outputs to PyTorch outputs by shape, return comparisons."""
+        coreml_items = list(coreml_out.items())
+        comparisons = []
+        for i, py_out in enumerate(py_outputs):
+            py_shape = tuple(py_out.shape)
+            oname = output_names[i] if output_names and i < len(output_names) else f"out_{i}"
+            matched = None
+            for cml_name, cml_val in coreml_items:
+                if tuple(cml_val.shape) == py_shape:
+                    matched = (cml_name, cml_val)
+                    coreml_items.remove((cml_name, cml_val))
+                    break
+            if matched is None:
+                py_size = py_out.numel()
+                for cml_name, cml_val in coreml_items:
+                    if cml_val.size == py_size:
+                        matched = (cml_name, cml_val)
+                        coreml_items.remove((cml_name, cml_val))
+                        break
+            if matched:
+                # Use active_length for first output (audio) only
+                al = active_length if i == 0 else None
+                comp = compare_tensors(py_out, matched[1], active_length=al)
+                comp["name"] = oname
+                comparisons.append(comp)
+            else:
+                comparisons.append({"name": oname, "corr": 0, "mse": 0, "max_diff": 0, "error": "no_shape_match"})
+        return comparisons
+
+    # PyTorch vs CPU
+    if cpu_out is not None:
+        cpu_comps = _match_and_compare(py_outputs, cpu_out, output_names, active_length=active_length)
+        result["cpu_corr"] = cpu_comps[0]["corr"] if cpu_comps else 0
+        result["cpu_comparisons"] = cpu_comps
+
+    # PyTorch vs ANE
+    if ane_out is not None:
+        ane_comps = _match_and_compare(py_outputs, ane_out, output_names, active_length=active_length)
+        result["ane_corr"] = ane_comps[0]["corr"] if ane_comps else 0
+        result["comparisons"] = ane_comps  # primary comparisons = ANE
+    elif cpu_out is not None:
+        result["comparisons"] = result.get("cpu_comparisons", [])
+
+    result["status"] = "ok"
+    result["corr"] = result.get("ane_corr", result.get("cpu_corr", 0))
+
+    return result, py_outputs
+
+
+def test_pipeline_stage(name, frontend_module, backend_module,
+                        frontend_inputs, frontend_specs,
+                        backend_extra_inputs, backend_extra_specs,
+                        py_reference_output, output_names=None,
+                        active_length=None):
+    """Test a two-model pipeline: frontend on CPU_ONLY, backend on ALL.
+
+    Correlation is measured against py_reference_output.
+    """
+    result = {"name": name, "status": "unknown"}
+    frontend_module.eval()
+    backend_module.eval()
+
+    # Trace and convert frontend (CPU-only)
+    try:
+        with torch.no_grad():
+            fe_traced = torch.jit.trace(frontend_module, frontend_inputs, check_trace=False)
+        fe_model = ct.convert(
+            fe_traced, inputs=frontend_specs,
+            minimum_deployment_target=ct.target.macOS15,
+            compute_precision=ct.precision.FLOAT32,
+            convert_to="mlprogram",
+        )
+    except Exception as e:
+        result["status"] = "frontend_convert_error"
+        result["error"] = str(e)
+        return result
+
+    # Trace and convert backend (ANE-eligible)
+    try:
+        with torch.no_grad():
+            fe_py_out = frontend_module(*frontend_inputs)
+        backend_inputs = backend_extra_inputs + (fe_py_out,)
+        backend_specs_full = backend_extra_specs + [
+            ct.TensorType(name="har", shape=fe_py_out.shape, dtype=np.float32)]
+
+        with torch.no_grad():
+            be_traced = torch.jit.trace(backend_module, backend_inputs, check_trace=False)
+        be_model = ct.convert(
+            be_traced, inputs=backend_specs_full,
+            minimum_deployment_target=ct.target.macOS15,
+            compute_precision=ct.precision.FLOAT32,
+            convert_to="mlprogram",
+        )
+    except Exception as e:
+        result["status"] = "backend_convert_error"
+        result["error"] = str(e)
+        return result
+
+    # Build feed dicts
+    fe_feed = {}
+    for spec, tensor in zip(frontend_specs, frontend_inputs):
+        fe_feed[spec.name] = tensor.numpy().astype(np.float32) \
+            if tensor.dtype in (torch.float32, torch.float64) \
+            else tensor.numpy().astype(np.int32)
+
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmpdir:
+        fe_path = os.path.join(tmpdir, "frontend.mlpackage")
+        be_path = os.path.join(tmpdir, "backend.mlpackage")
+        fe_model.save(fe_path)
+        be_model.save(be_path)
+
+        WARMUP_RUNS = 2
+        TIMED_RUNS = 3
+
+        # Load frontend CPU-only, backend ALL (ANE)
+        ml_fe = ct.models.MLModel(fe_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+        ml_be = ct.models.MLModel(be_path, compute_units=ct.ComputeUnit.ALL)
+
+        # Build backend feed (extra inputs + frontend output)
+        def _run_pipeline():
+            fe_out = ml_fe.predict(fe_feed)
+            har_val = list(fe_out.values())[0]  # single output
+            be_feed = {}
+            for spec, tensor in zip(backend_extra_specs, backend_extra_inputs):
+                be_feed[spec.name] = tensor.numpy().astype(np.float32)
+            be_feed["har"] = har_val.astype(np.float32)
+            return ml_be.predict(be_feed)
+
+        # Cold run
+        t0 = time.time()
+        ane_out = _run_pipeline()
+        result["predict_time_ane_cold"] = round(time.time() - t0, 3)
+
+        # Warm up
+        for _ in range(WARMUP_RUNS):
+            _run_pipeline()
+
+        # Timed runs
+        t0 = time.time()
+        for _ in range(TIMED_RUNS):
+            ane_out = _run_pipeline()
+        result["predict_time_ane"] = round((time.time() - t0) / TIMED_RUNS, 3)
+        result["ane_ok"] = True
+
+        # Also time CPU-only backend for comparison
+        ml_be_cpu = ct.models.MLModel(be_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+
+        def _run_pipeline_cpu():
+            fe_out = ml_fe.predict(fe_feed)
+            har_val = list(fe_out.values())[0]
+            be_feed = {}
+            for spec, tensor in zip(backend_extra_specs, backend_extra_inputs):
+                be_feed[spec.name] = tensor.numpy().astype(np.float32)
+            be_feed["har"] = har_val.astype(np.float32)
+            return ml_be_cpu.predict(be_feed)
+
+        t0 = time.time()
+        cpu_out = _run_pipeline_cpu()
+        result["predict_time_cpu_cold"] = round(time.time() - t0, 3)
+        for _ in range(WARMUP_RUNS):
+            _run_pipeline_cpu()
+        t0 = time.time()
+        for _ in range(TIMED_RUNS):
+            cpu_out = _run_pipeline_cpu()
+        result["predict_time_cpu"] = round((time.time() - t0) / TIMED_RUNS, 3)
+        result["cpu_ok"] = True
+
+    # Compare against PyTorch reference
+    py_outputs = (py_reference_output,) if not isinstance(py_reference_output, tuple) else py_reference_output
+
+    if ane_out is not None:
+        ane_comps = _match_and_compare(py_outputs, ane_out, output_names, active_length=active_length)
+        result["ane_corr"] = ane_comps[0]["corr"] if ane_comps else 0
+        result["comparisons"] = ane_comps
+
+    if cpu_out is not None:
+        cpu_comps = _match_and_compare(py_outputs, cpu_out, output_names, active_length=active_length)
+        result["cpu_corr"] = cpu_comps[0]["corr"] if cpu_comps else 0
+        result["cpu_comparisons"] = cpu_comps
+
+    result["status"] = "ok"
+    result["corr"] = result.get("ane_corr", result.get("cpu_corr", 0))
+    return result
+
+
+def _match_and_compare(py_outputs, coreml_out, output_names, active_length=None):
+    """Match CoreML outputs to PyTorch outputs by shape, return comparisons."""
+    coreml_items = list(coreml_out.items())
+    comparisons = []
+    for i, py_out in enumerate(py_outputs):
+        py_shape = tuple(py_out.shape)
+        oname = output_names[i] if output_names and i < len(output_names) else f"out_{i}"
+        matched = None
+        for cml_name, cml_val in coreml_items:
+            if tuple(cml_val.shape) == py_shape:
+                matched = (cml_name, cml_val)
+                coreml_items.remove((cml_name, cml_val))
+                break
+        if matched is None:
+            py_size = py_out.numel()
+            for cml_name, cml_val in coreml_items:
+                if cml_val.size == py_size:
+                    matched = (cml_name, cml_val)
+                    coreml_items.remove((cml_name, cml_val))
+                    break
+        if matched:
+            al = active_length if i == 0 else None
+            comp = compare_tensors(py_out, matched[1], active_length=al)
+            comp["name"] = oname
+            comparisons.append(comp)
+        else:
+            comparisons.append({"name": oname, "corr": 0, "mse": 0, "max_diff": 0, "error": "no_shape_match"})
+    return comparisons
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def load_model():
+    from kokoro import KPipeline
+    from export_coreml import CustomSTFT
+
+    pipeline = KPipeline(lang_code="a")
+    model = pipeline.model
+    model.eval()
+
+    gen = model.decoder.generator
+    gen.stft = CustomSTFT(
+        filter_length=gen.stft.filter_length,
+        hop_length=gen.stft.hop_length,
+        win_length=gen.stft.win_length,
+    )
+
+    set_phases_fn = patch_sinegen_for_export(model)
+    return pipeline, model, set_phases_fn
+
+
+def run_pytorch_pipeline(model, set_phases_fn, token_ids, ref_s, max_tokens, max_frames):
+    """Run full pipeline in PyTorch, capturing all intermediates."""
+    intermediates = {}
+
+    input_ids = torch.zeros(1, max_tokens, dtype=torch.int64)
+    seq_len = min(len(token_ids), max_tokens)
+    input_ids[0, :seq_len] = torch.tensor(token_ids[:seq_len])
+    attention_mask = torch.zeros(1, max_tokens, dtype=torch.int64)
+    attention_mask[0, :seq_len] = 1
+    speed = torch.tensor([1.0])
+    phases = torch.rand(1, 9) * 2 * torch.pi
+
+    set_phases_fn(model.decoder, phases)
+
+    with torch.no_grad():
+        input_lengths = attention_mask.sum(dim=1).long()
+        text_mask = (attention_mask == 0)
+
+        # Stage 1: BERT
+        bert_dur = model.bert(input_ids, attention_mask=attention_mask)
+        d_en = model.bert_encoder(bert_dur).transpose(-1, -2)
+        intermediates["d_en"] = d_en
+
+        s = ref_s[:, 128:]
+        s_content = ref_s[:, :128]
+        intermediates["s"] = s
+        intermediates["s_content"] = s_content
+
+        # Stage 2: Duration
+        d = model.predictor.text_encoder(d_en, s, input_lengths, text_mask)
+        intermediates["d"] = d
+        x, _ = model.predictor.lstm(d)
+        duration = model.predictor.duration_proj(x)
+        duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
+        pred_dur = torch.round(duration).clamp(min=1).long()
+        pred_dur = pred_dur * attention_mask.long()
+        intermediates["pred_dur"] = pred_dur
+
+        # Stage 3: Alignment
+        cumsum = torch.cumsum(pred_dur, dim=-1)
+        total_frames = cumsum[0, -1]
+        frame_indices = torch.arange(max_frames, device=input_ids.device).unsqueeze(0)
+        starts = F.pad(cumsum[:, :-1], (1, 0))
+        pred_aln_trg = (
+            (frame_indices.unsqueeze(1) >= starts.unsqueeze(2)) &
+            (frame_indices.unsqueeze(1) < cumsum.unsqueeze(2))
+        ).float()
+        intermediates["pred_aln_trg"] = pred_aln_trg
+        intermediates["total_frames"] = total_frames
+
+        # Stage 4: F0/N
+        en = d.transpose(-1, -2) @ pred_aln_trg
+        intermediates["en"] = en
+        F0_pred, N_pred = model.predictor.F0Ntrain(en, s)
+        intermediates["F0_pred"] = F0_pred
+        intermediates["N_pred"] = N_pred
+
+        # Stage 5: Text encoder
+        t_en = model.text_encoder(input_ids, input_lengths, text_mask)
+        intermediates["t_en"] = t_en
+        asr = t_en @ pred_aln_trg
+        intermediates["asr"] = asr
+
+        # Stage 6: Decoder
+        audio = model.decoder(asr, F0_pred, N_pred, s_content)
+        intermediates["audio"] = audio
+
+    # Store inputs for stage testing
+    intermediates["input_ids"] = input_ids
+    intermediates["attention_mask"] = attention_mask
+    intermediates["input_lengths"] = input_lengths
+    intermediates["text_mask"] = text_mask
+    intermediates["speed"] = speed
+    intermediates["phases"] = phases
+    intermediates["ref_s"] = ref_s
+
+    return intermediates
+
+
+def _build_stage_configs(model, im, max_frames):
+    """Build stage test configurations. Returns list of (stage_num, name, module, inputs, specs, output_names)."""
+    stages = []
+
+    stages.append((1, "1_bert", Stage1_BERT(model),
+        (im["input_ids"], im["attention_mask"]),
+        [ct.TensorType(name="input_ids", shape=im["input_ids"].shape, dtype=np.int32),
+         ct.TensorType(name="attention_mask", shape=im["attention_mask"].shape, dtype=np.int32)],
+        ["d_en"]))
+
+    stages.append((2, "2_duration", Stage2_Duration(model),
+        (im["d_en"], im["s"], im["input_lengths"], im["text_mask"], im["speed"], im["attention_mask"]),
+        [ct.TensorType(name="d_en", shape=im["d_en"].shape, dtype=np.float32),
+         ct.TensorType(name="s", shape=im["s"].shape, dtype=np.float32),
+         ct.TensorType(name="input_lengths", shape=im["input_lengths"].shape, dtype=np.int32),
+         ct.TensorType(name="text_mask", shape=im["text_mask"].shape, dtype=np.int32),
+         ct.TensorType(name="speed", shape=im["speed"].shape, dtype=np.float32),
+         ct.TensorType(name="attention_mask", shape=im["attention_mask"].shape, dtype=np.int32)],
+        ["pred_dur", "d"]))
+
+    stages.append((3, "3_alignment", Stage3_Alignment(max_frames),
+        (im["pred_dur"],),
+        [ct.TensorType(name="pred_dur", shape=im["pred_dur"].shape, dtype=np.int32)],
+        ["pred_aln_trg", "total_frames"]))
+
+    stages.append((4, "4_f0n", Stage4_F0N(model),
+        (im["d"], im["pred_aln_trg"], im["s"]),
+        [ct.TensorType(name="d", shape=im["d"].shape, dtype=np.float32),
+         ct.TensorType(name="pred_aln_trg", shape=im["pred_aln_trg"].shape, dtype=np.float32),
+         ct.TensorType(name="s", shape=im["s"].shape, dtype=np.float32)],
+        ["F0_pred", "N_pred"]))
+
+    stages.append((5, "5_text_enc", Stage5_TextEncoder(model),
+        (im["input_ids"], im["input_lengths"], im["text_mask"], im["pred_aln_trg"]),
+        [ct.TensorType(name="input_ids", shape=im["input_ids"].shape, dtype=np.int32),
+         ct.TensorType(name="input_lengths", shape=im["input_lengths"].shape, dtype=np.int32),
+         ct.TensorType(name="text_mask", shape=im["text_mask"].shape, dtype=np.int32),
+         ct.TensorType(name="pred_aln_trg", shape=im["pred_aln_trg"].shape, dtype=np.float32)],
+        ["asr"]))
+
+    stages.append((6, "6_decoder", Stage6_Decoder(model),
+        (im["asr"], im["F0_pred"], im["N_pred"], im["s_content"]),
+        [ct.TensorType(name="asr", shape=im["asr"].shape, dtype=np.float32),
+         ct.TensorType(name="F0_pred", shape=im["F0_pred"].shape, dtype=np.float32),
+         ct.TensorType(name="N_pred", shape=im["N_pred"].shape, dtype=np.float32),
+         ct.TensorType(name="s_content", shape=im["s_content"].shape, dtype=np.float32)],
+        ["audio"]))
+
+    # Stage 7 needs the decoder's pre-generator output
+    try:
+        with torch.no_grad():
+            dec = model.decoder
+            F0 = dec.F0_conv(im["F0_pred"].unsqueeze(1))
+            N = dec.N_conv(im["N_pred"].unsqueeze(1))
+            x = torch.cat([im["asr"], F0, N], axis=1)
+            x = dec.encode(x, im["s_content"])
+            asr_res = dec.asr_res(im["asr"])
+            res = True
+            for block in dec.decode:
+                if res:
+                    x = torch.cat([x, asr_res, F0, N], axis=1)
+                x = block(x, im["s_content"])
+                if block.upsample_type != "none":
+                    res = False
+            gen_input = x
+
+        stages.append((7, "7_generator", Stage7_Generator(model),
+            (gen_input, im["s_content"], im["F0_pred"]),
+            [ct.TensorType(name="x", shape=gen_input.shape, dtype=np.float32),
+             ct.TensorType(name="s", shape=im["s_content"].shape, dtype=np.float32),
+             ct.TensorType(name="f0_curve", shape=im["F0_pred"].shape, dtype=np.float32)],
+            ["audio"]))
+    except Exception as e:
+        stages.append((7, "7_generator", None, None, None, None))
+
+    # ---- Split models ----
+    # Split A: stages 1-5 combined (predictor)
+    stages.append((8, "split_A", SplitA_Predictor(model, max_frames),
+        (im["input_ids"], im["attention_mask"], im["ref_s"], im["speed"]),
+        [ct.TensorType(name="input_ids", shape=im["input_ids"].shape, dtype=np.int32),
+         ct.TensorType(name="attention_mask", shape=im["attention_mask"].shape, dtype=np.int32),
+         ct.TensorType(name="ref_s", shape=im["ref_s"].shape, dtype=np.float32),
+         ct.TensorType(name="speed", shape=im["speed"].shape, dtype=np.float32)],
+        ["asr", "F0_pred", "N_pred", "total_frames"]))
+
+    # Split B: stage 6 (decoder)
+    stages.append((9, "split_B", SplitB_Decoder(model),
+        (im["asr"], im["F0_pred"], im["N_pred"], im["s_content"]),
+        [ct.TensorType(name="asr", shape=im["asr"].shape, dtype=np.float32),
+         ct.TensorType(name="F0_pred", shape=im["F0_pred"].shape, dtype=np.float32),
+         ct.TensorType(name="N_pred", shape=im["N_pred"].shape, dtype=np.float32),
+         ct.TensorType(name="s_content", shape=im["s_content"].shape, dtype=np.float32)],
+        ["audio"]))
+
+    return stages
+
+
+def run_all_stages(model, intermediates, max_frames, only_stage=None):
+    """Run all stage tests (or a single stage), return results list."""
+    configs = _build_stage_configs(model, intermediates, max_frames)
+    results = []
+
+    # Active audio length for trimming garbage tail in correlation
+    active_audio = int(intermediates["total_frames"].item()) * SAMPLES_PER_FRAME
+    # Stages that output audio (6=decoder, 7=generator, 9=split_B)
+    audio_stages = {6, 7, 9}
+
+    for stage_num, name, module, inputs, specs, output_names in configs:
+        if only_stage is not None and only_stage != stage_num:
+            continue
+
+        if module is None:
+            results.append({"name": name, "status": "setup_error", "error": "failed to build"})
+            continue
+
+        al = active_audio if stage_num in audio_stages else None
+        r, _ = test_stage(name, module, inputs, specs, output_names=output_names, active_length=al)
+        results.append(r)
+
+    # Pipeline split stages (stage 10 = generator pipeline)
+    if only_stage is None or only_stage == 10:
+        try:
+            gen = model.decoder.generator
+            fe = GeneratorFrontEnd(gen)
+            be = GeneratorBackEnd(gen)
+
+            # Compute pre-generator input (same as stage 7 setup)
+            with torch.no_grad():
+                dec = model.decoder
+                F0 = dec.F0_conv(intermediates["F0_pred"].unsqueeze(1))
+                N = dec.N_conv(intermediates["N_pred"].unsqueeze(1))
+                x = torch.cat([intermediates["asr"], F0, N], axis=1)
+                x = dec.encode(x, intermediates["s_content"])
+                asr_res = dec.asr_res(intermediates["asr"])
+                res = True
+                for block in dec.decode:
+                    if res:
+                        x = torch.cat([x, asr_res, F0, N], axis=1)
+                    x = block(x, intermediates["s_content"])
+                    if block.upsample_type != "none":
+                        res = False
+                gen_input = x
+
+            r = test_pipeline_stage(
+                "10_gen_pipe",
+                fe, be,
+                frontend_inputs=(intermediates["F0_pred"],),
+                frontend_specs=[
+                    ct.TensorType(name="f0_curve", shape=intermediates["F0_pred"].shape,
+                                  dtype=np.float32)],
+                backend_extra_inputs=(gen_input, intermediates["s_content"]),
+                backend_extra_specs=[
+                    ct.TensorType(name="x", shape=gen_input.shape, dtype=np.float32),
+                    ct.TensorType(name="s", shape=intermediates["s_content"].shape,
+                                  dtype=np.float32)],
+                py_reference_output=intermediates["audio"],
+                output_names=["audio"],
+                active_length=active_audio,
+            )
+            results.append(r)
+        except Exception as e:
+            results.append({"name": "10_gen_pipe", "status": "setup_error",
+                           "error": str(e)[:80]})
+
+    # Stage 11: Full decoder pipeline (frontend CPU + decoder backend ANE)
+    if only_stage is None or only_stage == 11:
+        try:
+            gen = model.decoder.generator
+            fe = GeneratorFrontEnd(gen)
+            be = DecoderBackEnd(model.decoder)
+
+            r = test_pipeline_stage(
+                "11_dec_pipe",
+                fe, be,
+                frontend_inputs=(intermediates["F0_pred"],),
+                frontend_specs=[
+                    ct.TensorType(name="f0_curve", shape=intermediates["F0_pred"].shape,
+                                  dtype=np.float32)],
+                backend_extra_inputs=(
+                    intermediates["asr"], intermediates["F0_pred"],
+                    intermediates["N_pred"], intermediates["s_content"]),
+                backend_extra_specs=[
+                    ct.TensorType(name="asr", shape=intermediates["asr"].shape, dtype=np.float32),
+                    ct.TensorType(name="F0_curve", shape=intermediates["F0_pred"].shape, dtype=np.float32),
+                    ct.TensorType(name="N", shape=intermediates["N_pred"].shape, dtype=np.float32),
+                    ct.TensorType(name="s", shape=intermediates["s_content"].shape, dtype=np.float32)],
+                py_reference_output=intermediates["audio"],
+                output_names=["audio"],
+                active_length=active_audio,
+            )
+            results.append(r)
+        except Exception as e:
+            results.append({"name": "11_dec_pipe", "status": "setup_error",
+                           "error": str(e)[:80]})
+
+    return results
+
+
+def print_results(results):
+    """Pretty-print stage results."""
+    w = 88
+    print(f"\n{'='*w}")
+    print(f"{'Stage':<16} {'Status':<8} "
+          f"{'CPU Corr':>9} {'Cold':>6} {'Warm':>6}  "
+          f"{'ANE Corr':>9} {'Cold':>6} {'Warm':>6}")
+    print(f"{'-'*w}")
+
+    for r in results:
+        name = r["name"]
+        status = r["status"]
+
+        if status == "ok":
+            ane_ok = r.get("ane_ok", False)
+            cpu_ok = r.get("cpu_ok", False)
+            cpu_corr = r.get("cpu_corr", None)
+            ane_corr = r.get("ane_corr", None)
+            ane_cold = r.get("predict_time_ane_cold", 0)
+            ane_warm = r.get("predict_time_ane", 0)
+            cpu_cold = r.get("predict_time_cpu_cold", 0)
+            cpu_warm = r.get("predict_time_cpu", 0)
+
+            # FAIL if ANE doesn't run
+            if not ane_ok:
+                flag = "FAIL"
+            elif ane_corr is not None and ane_corr > 0.99:
+                flag = "PASS"
+            elif ane_corr is not None and ane_corr > 0.9:
+                flag = "WARN"
+            else:
+                flag = "FAIL"
+
+            def _fmt_corr(c):
+                return f"{c:.4f}" if c is not None else "---"
+            def _fmt_time(t, ok):
+                return f"{t*1000:.0f}ms" if ok else "FAIL"
+
+            print(f"{name:<16} {flag:<8} "
+                  f"{_fmt_corr(cpu_corr):>9} {_fmt_time(cpu_cold, cpu_ok):>6} {_fmt_time(cpu_warm, cpu_ok):>6}  "
+                  f"{_fmt_corr(ane_corr):>9} {_fmt_time(ane_cold, ane_ok):>6} {_fmt_time(ane_warm, ane_ok):>6}")
+
+            # Sub-outputs (from ANE comparisons)
+            c = r.get("comparisons", [])
+            for ci in c[1:]:
+                oname = ci.get("name", "?")
+                print(f"  └─ {oname:<39}  "
+                      f"{ci['corr']:>9.4f}")
+        else:
+            err = r.get("error", "")[:40]
+            print(f"{name:<16} {status:<8} {'':>9} {'':>6} {'':>6}  "
+                  f"{'':>9} {'':>6} {'':>6}  {err}")
+
+    print(f"{'='*w}")
+
+
+TEST_SENTENCES = {
+    "short":  "Hello world.",
+    "medium": "She sells seashells by the seashore, and the shells she sells are seashells for sure.",
+    "long":   "It was the best of times, it was the worst of times, it was the age of wisdom, it was the age of foolishness, it was the epoch of belief, it was the epoch of incredulity.",
+}
+
+
+def _tokenize(text, pipeline, model):
+    """Convert text to token IDs with start/end tokens."""
+    phonemes, _ = pipeline.g2p(text)
+    raw = list(filter(lambda i: i is not None,
+        map(lambda p: model.vocab.get(p), phonemes)))
+    return [0] + raw + [0]
+
+
+def _merge_results(all_runs):
+    """Merge results across multiple sentences — report worst-case corr, avg timing."""
+    merged = {}
+    for results in all_runs:
+        for r in results:
+            name = r["name"]
+            if name not in merged:
+                merged[name] = {**r, "_runs": 1}
+                continue
+
+            m = merged[name]
+            m["_runs"] += 1
+
+            if r["status"] != "ok":
+                m["status"] = r["status"]
+                continue
+
+            # Worst-case correlations
+            for key in ("cpu_corr", "ane_corr"):
+                if key in r and key in m:
+                    if r[key] is not None and m[key] is not None:
+                        m[key] = min(m[key], r[key])
+
+            # Average timings
+            for key in ("predict_time_cpu", "predict_time_ane",
+                        "predict_time_cpu_cold", "predict_time_ane_cold"):
+                if key in r and key in m:
+                    m[key] = (m[key] * (m["_runs"] - 1) + r[key]) / m["_runs"]
+
+            # Worst-case ANE/CPU ok
+            for key in ("ane_ok", "cpu_ok"):
+                if key in r:
+                    m[key] = m.get(key, True) and r[key]
+
+            # Update overall corr to worst ANE
+            m["corr"] = m.get("ane_corr", m.get("cpu_corr", 0))
+
+    return list(merged.values())
+
+
+MINIMUM_EXPERIMENT_SECONDS = 300  # 5 minutes
+
+
+def _emit_results(all_runs, sentences, args):
+    """Format and print results (text or JSON)."""
+    if not args.json:
+        for label, results in zip(sentences.keys(), all_runs):
+            print(f"\n--- {label} ---")
+            print_results(results)
+
+        # Also print worst-case summary if multiple sentences
+        if len(all_runs) > 1:
+            merged = _merge_results(all_runs)
+            print(f"\n--- WORST CASE across {len(sentences)} sentences ---")
+            print_results(merged)
+    else:
+        out = {}
+        for label, results in zip(sentences.keys(), all_runs):
+            for r in results:
+                for c in r.get("comparisons", []):
+                    for k in list(c.keys()):
+                        if isinstance(c[k], (np.floating, np.integer)):
+                            c[k] = float(c[k])
+            out[label] = results
+        if len(all_runs) > 1:
+            merged = _merge_results(all_runs)
+            for r in merged:
+                r.pop("_runs", None)
+            out["worst_case"] = merged
+        print(json.dumps(out, indent=2))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stage-by-stage CoreML harness")
+    parser.add_argument("--stage", type=int,
+                        help="Run single stage (1-7, 8=split_A, 9=split_B)")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument("--text", default=None,
+                        help="Single test sentence (overrides multi-sentence)")
+    args = parser.parse_args()
+
+    experiment_start = time.time()
+
+    print("Loading model...")
+    pipeline, model, set_phases_fn = load_model()
+
+    from export_coreml import BUCKETS
+    bucket = BUCKETS["kokoro_21_5s"]
+    max_tokens = bucket["max_tokens"]
+    max_audio = bucket["max_audio"]
+    max_frames = max_audio // SAMPLES_PER_FRAME
+
+    voice_pack = pipeline.load_voice("af_heart")
+
+    # Build sentence list
+    if args.text:
+        sentences = {"custom": args.text}
+    else:
+        sentences = TEST_SENTENCES
+
+    all_runs = []
+    for label, text in sentences.items():
+        token_ids = _tokenize(text, pipeline, model)
+        seq_len = min(len(token_ids), max_tokens)
+
+        ref_s = voice_pack[seq_len]
+        if ref_s.dim() == 1:
+            ref_s = ref_s.unsqueeze(0)
+
+        print(f"\n[{label}] \"{text[:60]}{'...' if len(text)>60 else ''}\" "
+              f"({seq_len} tokens)")
+
+        intermediates = run_pytorch_pipeline(
+            model, set_phases_fn, token_ids, ref_s, max_tokens, max_frames
+        )
+        total = int(intermediates["total_frames"].item())
+        print(f"  frames: {total}, audio: {total * SAMPLES_PER_FRAME} samples")
+
+        results = run_all_stages(
+            model, intermediates, max_frames, only_stage=args.stage
+        )
+        all_runs.append(results)
+
+    # Enforce minimum experiment time before revealing results
+    elapsed = time.time() - experiment_start
+    remaining = MINIMUM_EXPERIMENT_SECONDS - elapsed
+    if remaining > 0:
+        print(f"\n{'='*88}")
+        print(f"Experiment complete. Withholding results until minimum experiment")
+        print(f"time of {MINIMUM_EXPERIMENT_SECONDS // 60} minutes has elapsed.")
+        print(f"Elapsed: {elapsed:.0f}s — waiting {remaining:.0f}s more...")
+        print(f"{'='*88}")
+        sys.stdout.flush()
+        time.sleep(remaining)
+        print(f"\nExperiment time reached. Releasing results.\n")
+
+    _emit_results(all_runs, sentences, args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
CoreML export infrastructure:

- `scripts/export_coreml.py` — export Kokoro to CoreML with inlined SineGen, CustomSTFT, pipeline split modules, and compatibility patches
- `scripts/stage_harness.py` — stage-by-stage evaluation harness comparing PyTorch vs CoreML across CPU and ANE
- `scripts/coreml_ops.py` — custom coremltools op registrations
- `research/program.md` — autoresearch experiment protocol

The pipeline splits the model at the STFT boundary: CPU frontend (SineGen + STFT) + ANE backend (generator backbone + iSTFT). This avoids the atan2 float16 precision issue on ANE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)