### PR TITLE
fix: trim leading BOS token audio to remove schwa onset artifact

### DIFF
--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -700,6 +700,15 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         var samples = MLArrayHelpers.extractFloats(from: audio, maxCount: validSamples)
+
+        // Drop audio generated for the leading BOS token (token id 0). The model
+        // assigns it real duration frames and synthesizes a short voiced onset —
+        // audible as a schwa before unvoiced fricatives (e.g. "uh-Switch").
+        if let leadingFrames = durations.first, leadingFrames > 0 {
+            let leadSamples = min(leadingFrames * Self.hopSize, samples.count)
+            samples.removeFirst(leadSamples)
+        }
+
         Self.removeTailArtifact(&samples)
         return (samples, durations)
     }


### PR DESCRIPTION
Hi 👋

First off, thanks for this library! I've been integrating it into some projects I'm working on and wanted to contribute a fix back for an audio artifact I'm encountering with short utterances:

Short single-word utterances whose first phoneme is an unvoiced fricative (e.g. "Switch" = /swˈɪʧ/) rendered with an audible "uh-" prefix — "Switch" came out as "Uh-Switch". Words starting with voiced onsets (e.g. "Rest" = /ɹˈɛst/) sounded fine.

Cause: Tokenizer.encode wraps every phoneme sequence as [0, …phonemes, 0] per the reference Kokoro implementation. The frontend duration predictor allocates real frames to the leading boundary token, and the backend decoder synthesizes a short voiced onset for it — acoustically a schwa. Before voiced continuants this blends in and is inaudible. Before unvoiced fricatives the voiced→voiceless transition reads as a distinct extra syllable. The existing removeTailArtifact handles the trailing BOS region but nothing handled the leading side, and applyFades only ramps 5ms (120 samples) — far shorter than the typical 25–75ms BOS allocation.

The artifact is speed-dependent: at speed 1.0 it is usually subtle enough to miss, but at speed 0.85 the BOS region expands proportionally and "Uh-Switch" becomes unmistakable.

Fix: in synthesizeChunk, after extracting samples from the backend, drop durations[0] * hopSize samples from the head. This uses the model's own per-token duration prediction, so we remove exactly the BOS region and nothing else. The existing applyFades fade-in then cleans up any boundary click at the new start. No change to the tail path — the RMS-based removeTailArtifact already handles trailing EOS.

Verified by regenerating samples on both main and this branch:

```
kokoro say "Switch" -s 0.85 -o /tmp/switch.wav
kokoro say "The quick brown fox jumps over the lazy dog." -o /tmp/longphrase.wav
```

At -s 0.85, baseline reproduces the "Uh-Switch" artifact and the branch does not. The long phrase produces identical audio duration (3.2s) on both, confirming nothing is clipped from real speech.