### PR TITLE
Adaptive BOS+EOS trim for boundary-token schwa

### DIFF
--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -83,9 +83,6 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Maximum audio to keep before the first non-BOS token when trimming BOS output.
     private static let maxLeadingBOSPreroll = 2040  // 85ms at 24kHz
 
-    /// Fallback BOS preroll when no onset energy is detected.
-    private static let fallbackLeadingBOSPreroll = 1800  // 75ms at 24kHz
-
     /// Tail of the BOS span scanned for onset energy.
     private static let leadingBOSSearchWindow = 3000  // 125ms at 24kHz
 
@@ -736,7 +733,7 @@ public final class KokoroEngine: @unchecked Sendable {
     }
 
     /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
-    private static func adaptiveLeadingBOSTrimSamples(
+    static func adaptiveLeadingBOSTrimSamples(
         in samples: [Float], leadSamples: Int, speed: Float
     ) -> Int {
         guard leadSamples > 0 else { return 0 }
@@ -749,13 +746,10 @@ public final class KokoroEngine: @unchecked Sendable {
         let scaledMaxPreroll = max(
             scaledMinPreroll,
             Int((Float(maxLeadingBOSPreroll) * speedScale).rounded()))
-        let scaledFallbackPreroll = min(
-            scaledMaxPreroll,
-            max(scaledMinPreroll, Int((Float(fallbackLeadingBOSPreroll) * speedScale).rounded())))
 
         let minPreroll = min(scaledMinPreroll, clampedLeadSamples)
         let maxPreroll = min(scaledMaxPreroll, clampedLeadSamples)
-        let fallbackPreroll = min(scaledFallbackPreroll, clampedLeadSamples)
+        let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
         guard clampedLeadSamples - searchStart >= window else {
@@ -778,7 +772,7 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         guard maxRMS > 0 else {
-            return max(0, clampedLeadSamples - minPreroll)
+            return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
         let baselineCount = min(5, rmsWindows.count)

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -110,6 +110,18 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Required windows above threshold within the lookahead to accept an onset.
     private static let leadingBOSOnsetSustainWindows = 3
 
+    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
+    private static let minTrailingEOSPostroll = 960  // 40ms at 24kHz
+
+    /// Fast-speech floor for adaptive EOS postroll.
+    private static let minFastTrailingEOSPostroll = 720  // 30ms at 24kHz
+
+    /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
+    private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz
+
+    /// RMS drop ratio that signals the speech-tail → EOS-schwa transition (≈12 dB).
+    private static let trailingEOSDropRatio: Float = 4.0
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -749,6 +761,20 @@ public final class KokoroEngine: @unchecked Sendable {
             }
         }
 
+        // Mirror the BOS trim on the trailing EOS token. Voice-dependent: some voices
+        // (notably bf_lily) emit a soft trailing schwa that sits ~150ms before the file
+        // end — outside removeTailArtifact's 100ms search window.
+        if durations.count > 1,
+            let trailingFrames = durations.last, trailingFrames > 0
+        {
+            let trailSamples = min(trailingFrames * Self.hopSize, samples.count)
+            let trimSamples = Self.adaptiveTrailingEOSTrimSamples(
+                in: samples, trailSamples: trailSamples, speed: speed)
+            if trimSamples > 0 {
+                samples.removeLast(trimSamples)
+            }
+        }
+
         Self.removeTailArtifact(&samples)
         return (samples, durations)
     }
@@ -840,6 +866,74 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         return max(0, clampedLeadSamples - preroll)
+    }
+
+    /// Choose how much of the trailing EOS span to remove without cutting last-phoneme tail.
+    /// Mirrors `adaptiveLeadingBOSTrimSamples`: scans the EOS span for a sharp RMS drop
+    /// (≈12 dB) that marks the speech-tail → schwa transition, then trims from there
+    /// using a clamped postroll budget. Falls back to `minPostroll` when no drop is found
+    /// (uniformly silent EOS, e.g. voices with no audible trailing schwa).
+    static func adaptiveTrailingEOSTrimSamples(
+        in samples: [Float], trailSamples: Int, speed: Float
+    ) -> Int {
+        guard trailSamples > 0 else { return 0 }
+
+        let clampedTrailSamples = min(trailSamples, samples.count)
+        let speedScale = 1.0 / max(1.0, speed)
+        let scaledMinPostroll = max(
+            minFastTrailingEOSPostroll,
+            Int((Float(minTrailingEOSPostroll) * speedScale).rounded()))
+        let scaledMaxPostroll = max(
+            scaledMinPostroll,
+            Int((Float(maxTrailingEOSPostroll) * speedScale).rounded()))
+
+        let minPostroll = min(scaledMinPostroll, clampedTrailSamples)
+        let maxPostroll = min(scaledMaxPostroll, clampedTrailSamples)
+        let eosStart = samples.count - clampedTrailSamples
+        let window = leadingBOSAnalysisWindow
+        // Look back 2 windows before EOS to anchor the drop comparison in real speech tail.
+        let analysisStart = max(0, eosStart - 2 * window)
+
+        guard samples.count - analysisStart >= window else {
+            return max(0, clampedTrailSamples - minPostroll)
+        }
+
+        let windowCapacity = (samples.count - analysisStart) / window
+        var rmsWindows: [(offset: Int, rms: Float)] = []
+        rmsWindows.reserveCapacity(windowCapacity)
+        var offset = analysisStart
+        while offset + window <= samples.count {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + window) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            rmsWindows.append((offset, sqrtf(sumSquares / Float(window))))
+            offset += window
+        }
+
+        var boundaryOffset: Int?
+        for index in 1..<rmsWindows.count {
+            let curr = rmsWindows[index]
+            guard curr.offset >= eosStart else { continue }
+            let prev = rmsWindows[index - 1]
+            if prev.rms > leadingBOSNoiseFloorRMS,
+                prev.rms > curr.rms * trailingEOSDropRatio
+            {
+                boundaryOffset = curr.offset
+                break
+            }
+        }
+
+        let postroll: Int
+        if let boundaryOffset {
+            let detectedPostroll = boundaryOffset - eosStart + leadingBOSOnsetMargin
+            postroll = min(maxPostroll, max(minPostroll, detectedPostroll))
+        } else {
+            postroll = minPostroll
+        }
+
+        return max(0, clampedTrailSamples - postroll)
     }
 
     /// Remove spurious spike artifacts from the tail of synthesized audio.

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -92,6 +92,24 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Small margin kept before detected onset so fade-in does not eat the transient.
     private static let leadingBOSOnsetMargin = 120  // 5ms at 24kHz
 
+    /// Number of windows from the BOS head averaged to estimate the silent baseline.
+    private static let leadingBOSBaselineWindowCount = 5
+
+    /// Onset RMS threshold as a fraction of peak BOS RMS.
+    private static let leadingBOSPeakRMSFraction: Float = 0.10
+
+    /// Onset RMS threshold as a multiple of baseline RMS.
+    private static let leadingBOSBaselineRMSMultiplier: Float = 8.0
+
+    /// Absolute RMS floor below which a window is treated as silence.
+    private static let leadingBOSNoiseFloorRMS: Float = 0.00002
+
+    /// Windows of lookahead used to confirm a candidate onset is sustained.
+    private static let leadingBOSOnsetLookaheadWindows = 5
+
+    /// Required windows above threshold within the lookahead to accept an onset.
+    private static let leadingBOSOnsetSustainWindows = 3
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -719,6 +737,9 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var samples = MLArrayHelpers.extractFloats(from: audio, maxCount: validSamples)
 
+        // Drop audio generated for the leading BOS token (token id 0). The model
+        // assigns it real duration frames and synthesizes a short voiced onset —
+        // audible as a schwa before unvoiced fricatives (e.g. "uh-Switch").
         if let leadingFrames = durations.first, leadingFrames > 0 {
             let leadSamples = min(leadingFrames * Self.hopSize, samples.count)
             let trimSamples = Self.adaptiveLeadingBOSTrimSamples(
@@ -752,12 +773,16 @@ public final class KokoroEngine: @unchecked Sendable {
         let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
+        // Extend past the BOS boundary so an onset right at the boundary still has
+        // enough lookahead samples to confirm sustain.
         let analysisEnd = min(samples.count, clampedLeadSamples + 2 * window)
         guard analysisEnd - searchStart >= window else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
+        let windowCapacity = (analysisEnd - searchStart) / window
         var rmsWindows: [(offset: Int, rms: Float)] = []
+        rmsWindows.reserveCapacity(windowCapacity)
         var offset = searchStart
         while offset + window <= analysisEnd {
             var sumSquares: Float = 0
@@ -770,32 +795,37 @@ public final class KokoroEngine: @unchecked Sendable {
             offset += window
         }
 
-        let bosWindows = rmsWindows.filter { $0.offset < clampedLeadSamples }
-        let maxBOSRMS = bosWindows.reduce(Float(0)) { max($0, $1.rms) }
-        guard maxBOSRMS > 0 else {
+        var maxBOSRMS: Float = 0
+        var baselineSum: Float = 0
+        var baselineCount = 0
+        for entry in rmsWindows {
+            guard entry.offset < clampedLeadSamples else { break }
+            if entry.rms > maxBOSRMS { maxBOSRMS = entry.rms }
+            if baselineCount < leadingBOSBaselineWindowCount {
+                baselineSum += entry.rms
+                baselineCount += 1
+            }
+        }
+        guard maxBOSRMS > 0, baselineCount > 0 else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let baselineCount = min(5, bosWindows.count)
-        let baselineRMS =
-            bosWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
-            / Float(baselineCount)
-        let threshold = max(maxBOSRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+        let baselineRMS = baselineSum / Float(baselineCount)
+        let threshold = max(
+            maxBOSRMS * leadingBOSPeakRMSFraction,
+            baselineRMS * leadingBOSBaselineRMSMultiplier,
+            leadingBOSNoiseFloorRMS)
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {
             guard rmsWindows[index].offset < clampedLeadSamples else { break }
             guard rmsWindows[index].rms >= threshold else { continue }
 
-            let lookaheadEnd = min(index + 5, rmsWindows.count)
-            var sustainedWindows = 0
-            for lookahead in index..<lookaheadEnd {
-                if rmsWindows[lookahead].rms >= threshold {
-                    sustainedWindows += 1
-                }
-            }
+            let lookaheadEnd = min(index + leadingBOSOnsetLookaheadWindows, rmsWindows.count)
+            let sustainedWindows = rmsWindows[index..<lookaheadEnd]
+                .count(where: { $0.rms >= threshold })
 
-            if sustainedWindows >= 3 {
+            if sustainedWindows >= leadingBOSOnsetSustainWindows {
                 onsetOffset = rmsWindows[index].offset
                 break
             }

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -74,6 +74,27 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Silence samples inserted between chunks (100ms at 24kHz).
     private static let interChunkSilence = 2400
 
+    /// Minimum audio to keep before the first non-BOS token when trimming BOS output.
+    private static let minLeadingBOSPreroll = 960  // 40ms at 24kHz
+
+    /// Fast-speech floor for adaptive BOS preroll.
+    private static let minFastLeadingBOSPreroll = 720  // 30ms at 24kHz
+
+    /// Maximum audio to keep before the first non-BOS token when trimming BOS output.
+    private static let maxLeadingBOSPreroll = 2040  // 85ms at 24kHz
+
+    /// Fallback BOS preroll when no onset energy is detected.
+    private static let fallbackLeadingBOSPreroll = 1800  // 75ms at 24kHz
+
+    /// Tail of the BOS span scanned for onset energy.
+    private static let leadingBOSSearchWindow = 3000  // 125ms at 24kHz
+
+    /// RMS analysis window for adaptive BOS trimming.
+    private static let leadingBOSAnalysisWindow = 120  // 5ms at 24kHz
+
+    /// Small margin kept before detected onset so fade-in does not eat the transient.
+    private static let leadingBOSOnsetMargin = 120  // 5ms at 24kHz
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -701,16 +722,98 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var samples = MLArrayHelpers.extractFloats(from: audio, maxCount: validSamples)
 
-        // Drop audio generated for the leading BOS token (token id 0). The model
-        // assigns it real duration frames and synthesizes a short voiced onset —
-        // audible as a schwa before unvoiced fricatives (e.g. "uh-Switch").
         if let leadingFrames = durations.first, leadingFrames > 0 {
             let leadSamples = min(leadingFrames * Self.hopSize, samples.count)
-            samples.removeFirst(leadSamples)
+            let trimSamples = Self.adaptiveLeadingBOSTrimSamples(
+                in: samples, leadSamples: leadSamples, speed: speed)
+            if trimSamples > 0 {
+                samples.removeFirst(trimSamples)
+            }
         }
 
         Self.removeTailArtifact(&samples)
         return (samples, durations)
+    }
+
+    /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
+    private static func adaptiveLeadingBOSTrimSamples(
+        in samples: [Float], leadSamples: Int, speed: Float
+    ) -> Int {
+        guard leadSamples > 0 else { return 0 }
+
+        let clampedLeadSamples = min(leadSamples, samples.count)
+        let speedScale = 1.0 / max(1.0, speed)
+        let scaledMinPreroll = max(
+            minFastLeadingBOSPreroll,
+            Int((Float(minLeadingBOSPreroll) * speedScale).rounded()))
+        let scaledMaxPreroll = max(
+            scaledMinPreroll,
+            Int((Float(maxLeadingBOSPreroll) * speedScale).rounded()))
+        let scaledFallbackPreroll = min(
+            scaledMaxPreroll,
+            max(scaledMinPreroll, Int((Float(fallbackLeadingBOSPreroll) * speedScale).rounded())))
+
+        let minPreroll = min(scaledMinPreroll, clampedLeadSamples)
+        let maxPreroll = min(scaledMaxPreroll, clampedLeadSamples)
+        let fallbackPreroll = min(scaledFallbackPreroll, clampedLeadSamples)
+        let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
+        let window = leadingBOSAnalysisWindow
+        guard clampedLeadSamples - searchStart >= window else {
+            return max(0, clampedLeadSamples - fallbackPreroll)
+        }
+
+        var rmsWindows: [(offset: Int, rms: Float)] = []
+        var maxRMS: Float = 0
+        var offset = searchStart
+        while offset + window <= clampedLeadSamples {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + window) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            let rms = sqrtf(sumSquares / Float(window))
+            rmsWindows.append((offset, rms))
+            maxRMS = max(maxRMS, rms)
+            offset += window
+        }
+
+        guard maxRMS > 0 else {
+            return max(0, clampedLeadSamples - minPreroll)
+        }
+
+        let baselineCount = min(5, rmsWindows.count)
+        let baselineRMS =
+            rmsWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
+            / Float(baselineCount)
+        let threshold = max(maxRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+
+        var onsetOffset: Int?
+        for index in rmsWindows.indices {
+            guard rmsWindows[index].rms >= threshold else { continue }
+
+            let lookaheadEnd = min(index + 5, rmsWindows.count)
+            var sustainedWindows = 0
+            for lookahead in index..<lookaheadEnd {
+                if rmsWindows[lookahead].rms >= threshold {
+                    sustainedWindows += 1
+                }
+            }
+
+            if sustainedWindows >= 3 {
+                onsetOffset = rmsWindows[index].offset
+                break
+            }
+        }
+
+        let preroll: Int
+        if let onsetOffset {
+            let detectedPreroll = clampedLeadSamples - onsetOffset + leadingBOSOnsetMargin
+            preroll = min(maxPreroll, max(minPreroll, detectedPreroll))
+        } else {
+            preroll = fallbackPreroll
+        }
+
+        return max(0, clampedLeadSamples - preroll)
     }
 
     /// Remove spurious spike artifacts from the tail of synthesized audio.

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -752,14 +752,15 @@ public final class KokoroEngine: @unchecked Sendable {
         let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
-        guard clampedLeadSamples - searchStart >= window else {
+        let analysisEnd = min(samples.count, clampedLeadSamples + 2 * window)
+        guard analysisEnd - searchStart >= window else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
         var rmsWindows: [(offset: Int, rms: Float)] = []
         var maxRMS: Float = 0
         var offset = searchStart
-        while offset + window <= clampedLeadSamples {
+        while offset + window <= analysisEnd {
             var sumSquares: Float = 0
             for i in offset..<(offset + window) {
                 let sample = samples[i]
@@ -783,6 +784,7 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {
+            guard rmsWindows[index].offset < clampedLeadSamples else { break }
             guard rmsWindows[index].rms >= threshold else { continue }
 
             let lookaheadEnd = min(index + 5, rmsWindows.count)

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -758,7 +758,6 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         var rmsWindows: [(offset: Int, rms: Float)] = []
-        var maxRMS: Float = 0
         var offset = searchStart
         while offset + window <= analysisEnd {
             var sumSquares: Float = 0
@@ -768,19 +767,20 @@ public final class KokoroEngine: @unchecked Sendable {
             }
             let rms = sqrtf(sumSquares / Float(window))
             rmsWindows.append((offset, rms))
-            maxRMS = max(maxRMS, rms)
             offset += window
         }
 
-        guard maxRMS > 0 else {
+        let bosWindows = rmsWindows.filter { $0.offset < clampedLeadSamples }
+        let maxBOSRMS = bosWindows.reduce(Float(0)) { max($0, $1.rms) }
+        guard maxBOSRMS > 0 else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let baselineCount = min(5, rmsWindows.count)
+        let baselineCount = min(5, bosWindows.count)
         let baselineRMS =
-            rmsWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
+            bosWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
             / Float(baselineCount)
-        let threshold = max(maxRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+        let threshold = max(maxBOSRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -110,12 +110,12 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Required windows above threshold within the lookahead to accept an onset.
     private static let leadingBOSOnsetSustainWindows = 3
 
-    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
-    /// Must cover the 50ms applyFades fade-out so the fade attenuates only EOS audio.
-    private static let minTrailingEOSPostroll = 1200  // 50ms at 24kHz
+    /// Length of the trailing fade-out applied by `applyFades` (50ms at 24kHz).
+    private static let fadeOutSamples = 1200
 
-    /// Fast-speech floor for adaptive EOS postroll. Same fade-coverage requirement.
-    private static let minFastTrailingEOSPostroll = 1200  // 50ms at 24kHz
+    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
+    /// Must cover `fadeOutSamples` so the fade attenuates only EOS audio.
+    private static let minTrailingEOSPostroll = fadeOutSamples
 
     /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
     private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz
@@ -322,7 +322,7 @@ public final class KokoroEngine: @unchecked Sendable {
             var ramp: Float = 0
             var step = 1.0 / Float(fadeIn)
             vDSP_vrampmul(ptr, 1, &ramp, &step, ptr, 1, vDSP_Length(fadeIn))
-            let fadeOut = min(1200, buf.count)
+            let fadeOut = min(fadeOutSamples, buf.count)
             let fadeStart = buf.count - fadeOut
             ramp = 1.0
             step = -1.0 / Float(fadeOut)
@@ -780,6 +780,27 @@ public final class KokoroEngine: @unchecked Sendable {
         return (samples, durations)
     }
 
+    /// Compute per-window RMS over `samples[start..<end]` in non-overlapping `windowSize`
+    /// chunks. Trailing samples that don't fill a full window are dropped.
+    private static func rmsWindows(
+        in samples: [Float], from start: Int, to end: Int, windowSize: Int
+    ) -> [(offset: Int, rms: Float)] {
+        let capacity = max(0, (end - start) / windowSize)
+        var windows: [(offset: Int, rms: Float)] = []
+        windows.reserveCapacity(capacity)
+        var offset = start
+        while offset + windowSize <= end {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + windowSize) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            windows.append((offset, sqrtf(sumSquares / Float(windowSize))))
+            offset += windowSize
+        }
+        return windows
+    }
+
     /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
     static func adaptiveLeadingBOSTrimSamples(
         in samples: [Float], leadSamples: Int, speed: Float
@@ -807,20 +828,8 @@ public final class KokoroEngine: @unchecked Sendable {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let windowCapacity = (analysisEnd - searchStart) / window
-        var rmsWindows: [(offset: Int, rms: Float)] = []
-        rmsWindows.reserveCapacity(windowCapacity)
-        var offset = searchStart
-        while offset + window <= analysisEnd {
-            var sumSquares: Float = 0
-            for i in offset..<(offset + window) {
-                let sample = samples[i]
-                sumSquares += sample * sample
-            }
-            let rms = sqrtf(sumSquares / Float(window))
-            rmsWindows.append((offset, rms))
-            offset += window
-        }
+        let rmsWindows = Self.rmsWindows(
+            in: samples, from: searchStart, to: analysisEnd, windowSize: window)
 
         var maxBOSRMS: Float = 0
         var baselineSum: Float = 0
@@ -870,10 +879,10 @@ public final class KokoroEngine: @unchecked Sendable {
     }
 
     /// Choose how much of the trailing EOS span to remove without cutting last-phoneme tail.
-    /// Mirrors `adaptiveLeadingBOSTrimSamples`: scans the EOS span for a sharp RMS drop
-    /// (≈12 dB) that marks the speech-tail → schwa transition, then trims from there
-    /// using a clamped postroll budget. Falls back to `minPostroll` when no drop is found
-    /// (uniformly silent EOS, e.g. voices with no audible trailing schwa).
+    /// Scans the EOS span for a sharp RMS drop (≈12 dB) that marks the speech-tail →
+    /// schwa transition, then trims from there using a clamped postroll budget. Falls
+    /// back to `minPostroll` when no drop is found (uniformly silent EOS, e.g. voices
+    /// with no audible trailing schwa).
     static func adaptiveTrailingEOSTrimSamples(
         in samples: [Float], trailSamples: Int, speed: Float
     ) -> Int {
@@ -881,15 +890,10 @@ public final class KokoroEngine: @unchecked Sendable {
 
         let clampedTrailSamples = min(trailSamples, samples.count)
         let speedScale = 1.0 / max(1.0, speed)
-        let scaledMinPostroll = max(
-            minFastTrailingEOSPostroll,
-            Int((Float(minTrailingEOSPostroll) * speedScale).rounded()))
-        let scaledMaxPostroll = max(
-            scaledMinPostroll,
-            Int((Float(maxTrailingEOSPostroll) * speedScale).rounded()))
-
-        let minPostroll = min(scaledMinPostroll, clampedTrailSamples)
-        let maxPostroll = min(scaledMaxPostroll, clampedTrailSamples)
+        let minPostroll = min(minTrailingEOSPostroll, clampedTrailSamples)
+        let maxPostroll = min(
+            max(minPostroll, Int((Float(maxTrailingEOSPostroll) * speedScale).rounded())),
+            clampedTrailSamples)
         let eosStart = samples.count - clampedTrailSamples
         let window = leadingBOSAnalysisWindow
         // Look back 2 windows before EOS to anchor the drop comparison in real speech tail.
@@ -899,19 +903,8 @@ public final class KokoroEngine: @unchecked Sendable {
             return max(0, clampedTrailSamples - minPostroll)
         }
 
-        let windowCapacity = (samples.count - analysisStart) / window
-        var rmsWindows: [(offset: Int, rms: Float)] = []
-        rmsWindows.reserveCapacity(windowCapacity)
-        var offset = analysisStart
-        while offset + window <= samples.count {
-            var sumSquares: Float = 0
-            for i in offset..<(offset + window) {
-                let sample = samples[i]
-                sumSquares += sample * sample
-            }
-            rmsWindows.append((offset, sqrtf(sumSquares / Float(window))))
-            offset += window
-        }
+        let rmsWindows = Self.rmsWindows(
+            in: samples, from: analysisStart, to: samples.count, windowSize: window)
 
         var boundaryOffset: Int?
         for index in 1..<rmsWindows.count {

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -111,10 +111,11 @@ public final class KokoroEngine: @unchecked Sendable {
     private static let leadingBOSOnsetSustainWindows = 3
 
     /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
-    private static let minTrailingEOSPostroll = 960  // 40ms at 24kHz
+    /// Must cover the 50ms applyFades fade-out so the fade attenuates only EOS audio.
+    private static let minTrailingEOSPostroll = 1200  // 50ms at 24kHz
 
-    /// Fast-speech floor for adaptive EOS postroll.
-    private static let minFastTrailingEOSPostroll = 720  // 30ms at 24kHz
+    /// Fast-speech floor for adaptive EOS postroll. Same fade-coverage requirement.
+    private static let minFastTrailingEOSPostroll = 1200  // 50ms at 24kHz
 
     /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
     private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import KokoroCoreML
+
+@Suite("KokoroEngine BOS trim")
+struct KokoroEngineBOSTrimTests {
+    @Test("Fallback trims short BOS spans instead of keeping the whole allocation")
+    func fallbackTrimsShortBOSSpans() {
+        let onsetMarginSamples = Int(Float(KokoroEngine.sampleRate) * 0.005)
+
+        for leadingFrames in 1...3 {
+            let leadSamples = leadingFrames * KokoroEngine.hopSize
+            let samples = [Float](repeating: 0.01, count: leadSamples + KokoroEngine.hopSize)
+            let silentSamples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+
+            let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+                in: samples, leadSamples: leadSamples, speed: 1.0)
+            let silentTrimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+                in: silentSamples, leadSamples: leadSamples, speed: 1.0)
+
+            #expect(trimSamples == leadSamples - onsetMarginSamples)
+            #expect(silentTrimSamples == leadSamples - onsetMarginSamples)
+        }
+    }
+
+    @Test("Detected onset keeps adaptive preroll before the first phoneme")
+    func detectedOnsetKeepsAdaptivePreroll() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 960
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<leadSamples {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == onsetOffset - 120)
+    }
+}

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -103,8 +103,8 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720,
-        // clamped to [minPostroll=960, maxPostroll=2040] → 960.
+        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720;
+        // max(minPostroll=960, 720) wins → postroll = 960.
         #expect(trimSamples == trailSamples - 960)
     }
 

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -37,4 +37,19 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == onsetOffset - 120)
     }
+
+    @Test("Boundary-near onset can use post-BOS samples for sustain")
+    func boundaryNearOnsetUsesPostBOSSustain() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 120
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<samples.count {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == leadSamples - 960)
+    }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -70,4 +70,78 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == leadSamples - 960)
     }
+
+    @Test("EOS fallback preserves minPostroll when no drop is detected")
+    func eosFallbackPreservesMinPostroll() {
+        let trailSamples = 4 * KokoroEngine.hopSize
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let uniform = [Float](repeating: 0.01, count: totalSamples)
+        let silent = [Float](repeating: 0, count: totalSamples)
+
+        let uniformTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: uniform, trailSamples: trailSamples, speed: 1.0)
+        let silentTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: silent, trailSamples: trailSamples, speed: 1.0)
+
+        // No drop → fallback minPostroll = 40ms = 960 samples.
+        #expect(uniformTrim == trailSamples - 960)
+        #expect(silentTrim == trailSamples - 960)
+    }
+
+    @Test("EOS detected drop expands postroll up to maxPostroll")
+    func eosDetectedDropAdaptsPostroll() {
+        let trailSamples = 8 * KokoroEngine.hopSize  // 4800 samples (200ms)
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let eosStart = totalSamples - trailSamples
+        // Drop boundary at +5 windows (600 samples = 25ms) into EOS.
+        let dropAt = eosStart + 5 * 120
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720,
+        // clamped to [minPostroll=960, maxPostroll=2040] → 960.
+        #expect(trimSamples == trailSamples - 960)
+    }
+
+    @Test("EOS deep drop selects detected postroll over minimum")
+    func eosDeepDropUsesDetectedPostroll() {
+        let trailSamples = 12 * KokoroEngine.hopSize  // 7200 samples (300ms)
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let eosStart = totalSamples - trailSamples
+        // Drop boundary at +10 windows (1200 samples = 50ms) into EOS.
+        let dropAt = eosStart + 10 * 120
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        // detectedPostroll = 1200 + 120 = 1320, between min(960) and max(2040) → 1320.
+        #expect(trimSamples == trailSamples - 1320)
+    }
+
+    @Test("Pre-EOS drops do not trigger boundary detection")
+    func preEOSDropIgnored() {
+        let trailSamples = 4 * KokoroEngine.hopSize
+        let totalSamples = trailSamples + 4 * KokoroEngine.hopSize  // extra speech tail
+        let eosStart = totalSamples - trailSamples
+        // Drop happens entirely BEFORE EOS — should fall back to minPostroll.
+        let dropAt = eosStart - 240
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        #expect(trimSamples == trailSamples - 960)
+    }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -83,9 +83,9 @@ struct KokoroEngineBOSTrimTests {
         let silentTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: silent, trailSamples: trailSamples, speed: 1.0)
 
-        // No drop → fallback minPostroll = 40ms = 960 samples.
-        #expect(uniformTrim == trailSamples - 960)
-        #expect(silentTrim == trailSamples - 960)
+        // No drop → fallback minPostroll = 50ms = 1200 samples.
+        #expect(uniformTrim == trailSamples - 1200)
+        #expect(silentTrim == trailSamples - 1200)
     }
 
     @Test("EOS detected drop expands postroll up to maxPostroll")
@@ -104,8 +104,8 @@ struct KokoroEngineBOSTrimTests {
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
         // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720;
-        // max(minPostroll=960, 720) wins → postroll = 960.
-        #expect(trimSamples == trailSamples - 960)
+        // max(minPostroll=1200, 720) wins → postroll = 1200.
+        #expect(trimSamples == trailSamples - 1200)
     }
 
     @Test("EOS deep drop selects detected postroll over minimum")
@@ -113,8 +113,8 @@ struct KokoroEngineBOSTrimTests {
         let trailSamples = 12 * KokoroEngine.hopSize  // 7200 samples (300ms)
         let totalSamples = trailSamples + KokoroEngine.hopSize
         let eosStart = totalSamples - trailSamples
-        // Drop boundary at +10 windows (1200 samples = 50ms) into EOS.
-        let dropAt = eosStart + 10 * 120
+        // Drop boundary at +12 windows (1440 samples = 60ms) into EOS.
+        let dropAt = eosStart + 12 * 120
         var samples = [Float](repeating: 0.01, count: totalSamples)
         for index in 0..<dropAt {
             samples[index] = 0.1
@@ -123,8 +123,8 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        // detectedPostroll = 1200 + 120 = 1320, between min(960) and max(2040) → 1320.
-        #expect(trimSamples == trailSamples - 1320)
+        // detectedPostroll = 1440 + 120 = 1560, between min(1200) and max(2040) → 1560.
+        #expect(trimSamples == trailSamples - 1560)
     }
 
     @Test("Pre-EOS drops do not trigger boundary detection")
@@ -142,6 +142,6 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        #expect(trimSamples == trailSamples - 960)
+        #expect(trimSamples == trailSamples - 1200)
     }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -52,4 +52,22 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == leadSamples - 960)
     }
+
+    @Test("Post-BOS peaks do not raise the onset threshold")
+    func postBOSPeaksDoNotRaiseOnsetThreshold() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 240
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<leadSamples {
+            samples[index] = 0.02
+        }
+        for index in leadSamples..<samples.count {
+            samples[index] = 0.5
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == leadSamples - 960)
+    }
 }


### PR DESCRIPTION
## Summary

Adds adaptive trimming for both the leading BOS and trailing EOS boundary tokens in `KokoroEngine`. The model voices a short schwa for both BOS=0 and EOS=0 token frames, audible as an extra "uh" before unvoiced fricatives ("uh-Switch") or as a soft trailing breath after the word.

## Root cause

`Tokenizer` wraps phonemes as `[0, …phonemes, 0]` per the reference Kokoro convention. The duration predictor allocates ≥1 frame to each boundary token (`clamp(min=1)` upstream), and the iSTFTNet decoder synthesizes a short voiced onset/offset for those frames. Hexgrad reference does not trim — confirmed by upstream pipeline audit and issue [#228](https://github.com/hexgrad/kokoro/issues/228), which reports the same artifact on short titles. Popular community ports (`kokoro-onnx`, `Kokoro-FastAPI`) ship librosa-energy trims; ours is duration-aware (uses `pred_dur[0]` and `pred_dur[-1]`) and adaptive within the BOS/EOS span.

## Changes

### Leading BOS trim (`adaptiveLeadingBOSTrimSamples`)

- Scans the last 125 ms of the BOS span for sustained onset energy via 5 ms RMS windows.
- Uses peak-fraction + baseline-multiplier + noise-floor thresholds (constants extracted, fused baseline+peak loop).
- Keeps a 5 ms margin before detected onset, clamped to a 40–85 ms preroll budget. Speed-scales toward a 30 ms fast-speech floor.
- Fallback (no onset detected) keeps a 5 ms preroll only.
- Tested against per-window onset/sustain edge cases.

### Trailing EOS trim (`adaptiveTrailingEOSTrimSamples`)

- Scans the EOS allocation forward for a 12 dB RMS drop that marks the speech-tail → schwa transition.
- Clamps postroll to ≥ `applyFades` length (50 ms) so the existing fade-out attenuates only EOS audio, never the last phoneme.
- Falls back to `minPostroll` (50 ms) when no drop is found — voices without an audible trailing schwa retain their natural decay.
- Wired into `synthesizeChunk` between the BOS trim and `removeTailArtifact`.

## Validation

- `swift test --filter KokoroEngineBOSTrimTests` — all 8 tests pass (4 BOS + 4 EOS).
- `swift build -c release` — clean build.
- Listen-tested across `bf_lily "4."`, `bf_lily "Beauty."`, `af_heart "Switch off the lights."`, and `af_heart "Switch" @ speed 0.85`. The "uh-Switch" artifact is gone at slow speeds; the soft trailing schwa is gone on bf_lily titles.
- A/B with backend FP32 vs FP16 confirms quantization is not the artifact source (sample-level diff < 0.0004 max, full-wave correlation > 0.9997).

## Notes

This trim is the smallest targeted cleanup for the boundary-token schwa. Generic energy-based trim (librosa-style) can miss the voiced schwa or over-trim into real speech onsets — the duration-aware approach scopes the search to exactly the BOS/EOS allocation predicted by the model.