### PR TITLE
Length-aware bidirectional LSTM in dynamic CoreML export

### DIFF
--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -83,9 +83,6 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Maximum audio to keep before the first non-BOS token when trimming BOS output.
     private static let maxLeadingBOSPreroll = 2040  // 85ms at 24kHz
 
-    /// Fallback BOS preroll when no onset energy is detected.
-    private static let fallbackLeadingBOSPreroll = 1800  // 75ms at 24kHz
-
     /// Tail of the BOS span scanned for onset energy.
     private static let leadingBOSSearchWindow = 3000  // 125ms at 24kHz
 
@@ -736,7 +733,7 @@ public final class KokoroEngine: @unchecked Sendable {
     }
 
     /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
-    private static func adaptiveLeadingBOSTrimSamples(
+    static func adaptiveLeadingBOSTrimSamples(
         in samples: [Float], leadSamples: Int, speed: Float
     ) -> Int {
         guard leadSamples > 0 else { return 0 }
@@ -749,13 +746,10 @@ public final class KokoroEngine: @unchecked Sendable {
         let scaledMaxPreroll = max(
             scaledMinPreroll,
             Int((Float(maxLeadingBOSPreroll) * speedScale).rounded()))
-        let scaledFallbackPreroll = min(
-            scaledMaxPreroll,
-            max(scaledMinPreroll, Int((Float(fallbackLeadingBOSPreroll) * speedScale).rounded())))
 
         let minPreroll = min(scaledMinPreroll, clampedLeadSamples)
         let maxPreroll = min(scaledMaxPreroll, clampedLeadSamples)
-        let fallbackPreroll = min(scaledFallbackPreroll, clampedLeadSamples)
+        let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
         guard clampedLeadSamples - searchStart >= window else {
@@ -778,7 +772,7 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         guard maxRMS > 0 else {
-            return max(0, clampedLeadSamples - minPreroll)
+            return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
         let baselineCount = min(5, rmsWindows.count)

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -110,6 +110,18 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Required windows above threshold within the lookahead to accept an onset.
     private static let leadingBOSOnsetSustainWindows = 3
 
+    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
+    private static let minTrailingEOSPostroll = 960  // 40ms at 24kHz
+
+    /// Fast-speech floor for adaptive EOS postroll.
+    private static let minFastTrailingEOSPostroll = 720  // 30ms at 24kHz
+
+    /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
+    private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz
+
+    /// RMS drop ratio that signals the speech-tail → EOS-schwa transition (≈12 dB).
+    private static let trailingEOSDropRatio: Float = 4.0
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -749,6 +761,20 @@ public final class KokoroEngine: @unchecked Sendable {
             }
         }
 
+        // Mirror the BOS trim on the trailing EOS token. Voice-dependent: some voices
+        // (notably bf_lily) emit a soft trailing schwa that sits ~150ms before the file
+        // end — outside removeTailArtifact's 100ms search window.
+        if durations.count > 1,
+            let trailingFrames = durations.last, trailingFrames > 0
+        {
+            let trailSamples = min(trailingFrames * Self.hopSize, samples.count)
+            let trimSamples = Self.adaptiveTrailingEOSTrimSamples(
+                in: samples, trailSamples: trailSamples, speed: speed)
+            if trimSamples > 0 {
+                samples.removeLast(trimSamples)
+            }
+        }
+
         Self.removeTailArtifact(&samples)
         return (samples, durations)
     }
@@ -840,6 +866,74 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         return max(0, clampedLeadSamples - preroll)
+    }
+
+    /// Choose how much of the trailing EOS span to remove without cutting last-phoneme tail.
+    /// Mirrors `adaptiveLeadingBOSTrimSamples`: scans the EOS span for a sharp RMS drop
+    /// (≈12 dB) that marks the speech-tail → schwa transition, then trims from there
+    /// using a clamped postroll budget. Falls back to `minPostroll` when no drop is found
+    /// (uniformly silent EOS, e.g. voices with no audible trailing schwa).
+    static func adaptiveTrailingEOSTrimSamples(
+        in samples: [Float], trailSamples: Int, speed: Float
+    ) -> Int {
+        guard trailSamples > 0 else { return 0 }
+
+        let clampedTrailSamples = min(trailSamples, samples.count)
+        let speedScale = 1.0 / max(1.0, speed)
+        let scaledMinPostroll = max(
+            minFastTrailingEOSPostroll,
+            Int((Float(minTrailingEOSPostroll) * speedScale).rounded()))
+        let scaledMaxPostroll = max(
+            scaledMinPostroll,
+            Int((Float(maxTrailingEOSPostroll) * speedScale).rounded()))
+
+        let minPostroll = min(scaledMinPostroll, clampedTrailSamples)
+        let maxPostroll = min(scaledMaxPostroll, clampedTrailSamples)
+        let eosStart = samples.count - clampedTrailSamples
+        let window = leadingBOSAnalysisWindow
+        // Look back 2 windows before EOS to anchor the drop comparison in real speech tail.
+        let analysisStart = max(0, eosStart - 2 * window)
+
+        guard samples.count - analysisStart >= window else {
+            return max(0, clampedTrailSamples - minPostroll)
+        }
+
+        let windowCapacity = (samples.count - analysisStart) / window
+        var rmsWindows: [(offset: Int, rms: Float)] = []
+        rmsWindows.reserveCapacity(windowCapacity)
+        var offset = analysisStart
+        while offset + window <= samples.count {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + window) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            rmsWindows.append((offset, sqrtf(sumSquares / Float(window))))
+            offset += window
+        }
+
+        var boundaryOffset: Int?
+        for index in 1..<rmsWindows.count {
+            let curr = rmsWindows[index]
+            guard curr.offset >= eosStart else { continue }
+            let prev = rmsWindows[index - 1]
+            if prev.rms > leadingBOSNoiseFloorRMS,
+                prev.rms > curr.rms * trailingEOSDropRatio
+            {
+                boundaryOffset = curr.offset
+                break
+            }
+        }
+
+        let postroll: Int
+        if let boundaryOffset {
+            let detectedPostroll = boundaryOffset - eosStart + leadingBOSOnsetMargin
+            postroll = min(maxPostroll, max(minPostroll, detectedPostroll))
+        } else {
+            postroll = minPostroll
+        }
+
+        return max(0, clampedTrailSamples - postroll)
     }
 
     /// Remove spurious spike artifacts from the tail of synthesized audio.

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -92,6 +92,24 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Small margin kept before detected onset so fade-in does not eat the transient.
     private static let leadingBOSOnsetMargin = 120  // 5ms at 24kHz
 
+    /// Number of windows from the BOS head averaged to estimate the silent baseline.
+    private static let leadingBOSBaselineWindowCount = 5
+
+    /// Onset RMS threshold as a fraction of peak BOS RMS.
+    private static let leadingBOSPeakRMSFraction: Float = 0.10
+
+    /// Onset RMS threshold as a multiple of baseline RMS.
+    private static let leadingBOSBaselineRMSMultiplier: Float = 8.0
+
+    /// Absolute RMS floor below which a window is treated as silence.
+    private static let leadingBOSNoiseFloorRMS: Float = 0.00002
+
+    /// Windows of lookahead used to confirm a candidate onset is sustained.
+    private static let leadingBOSOnsetLookaheadWindows = 5
+
+    /// Required windows above threshold within the lookahead to accept an onset.
+    private static let leadingBOSOnsetSustainWindows = 3
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -719,6 +737,9 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var samples = MLArrayHelpers.extractFloats(from: audio, maxCount: validSamples)
 
+        // Drop audio generated for the leading BOS token (token id 0). The model
+        // assigns it real duration frames and synthesizes a short voiced onset —
+        // audible as a schwa before unvoiced fricatives (e.g. "uh-Switch").
         if let leadingFrames = durations.first, leadingFrames > 0 {
             let leadSamples = min(leadingFrames * Self.hopSize, samples.count)
             let trimSamples = Self.adaptiveLeadingBOSTrimSamples(
@@ -752,12 +773,16 @@ public final class KokoroEngine: @unchecked Sendable {
         let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
+        // Extend past the BOS boundary so an onset right at the boundary still has
+        // enough lookahead samples to confirm sustain.
         let analysisEnd = min(samples.count, clampedLeadSamples + 2 * window)
         guard analysisEnd - searchStart >= window else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
+        let windowCapacity = (analysisEnd - searchStart) / window
         var rmsWindows: [(offset: Int, rms: Float)] = []
+        rmsWindows.reserveCapacity(windowCapacity)
         var offset = searchStart
         while offset + window <= analysisEnd {
             var sumSquares: Float = 0
@@ -770,32 +795,37 @@ public final class KokoroEngine: @unchecked Sendable {
             offset += window
         }
 
-        let bosWindows = rmsWindows.filter { $0.offset < clampedLeadSamples }
-        let maxBOSRMS = bosWindows.reduce(Float(0)) { max($0, $1.rms) }
-        guard maxBOSRMS > 0 else {
+        var maxBOSRMS: Float = 0
+        var baselineSum: Float = 0
+        var baselineCount = 0
+        for entry in rmsWindows {
+            guard entry.offset < clampedLeadSamples else { break }
+            if entry.rms > maxBOSRMS { maxBOSRMS = entry.rms }
+            if baselineCount < leadingBOSBaselineWindowCount {
+                baselineSum += entry.rms
+                baselineCount += 1
+            }
+        }
+        guard maxBOSRMS > 0, baselineCount > 0 else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let baselineCount = min(5, bosWindows.count)
-        let baselineRMS =
-            bosWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
-            / Float(baselineCount)
-        let threshold = max(maxBOSRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+        let baselineRMS = baselineSum / Float(baselineCount)
+        let threshold = max(
+            maxBOSRMS * leadingBOSPeakRMSFraction,
+            baselineRMS * leadingBOSBaselineRMSMultiplier,
+            leadingBOSNoiseFloorRMS)
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {
             guard rmsWindows[index].offset < clampedLeadSamples else { break }
             guard rmsWindows[index].rms >= threshold else { continue }
 
-            let lookaheadEnd = min(index + 5, rmsWindows.count)
-            var sustainedWindows = 0
-            for lookahead in index..<lookaheadEnd {
-                if rmsWindows[lookahead].rms >= threshold {
-                    sustainedWindows += 1
-                }
-            }
+            let lookaheadEnd = min(index + leadingBOSOnsetLookaheadWindows, rmsWindows.count)
+            let sustainedWindows = rmsWindows[index..<lookaheadEnd]
+                .count(where: { $0.rms >= threshold })
 
-            if sustainedWindows >= 3 {
+            if sustainedWindows >= leadingBOSOnsetSustainWindows {
                 onsetOffset = rmsWindows[index].offset
                 break
             }

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -74,6 +74,27 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Silence samples inserted between chunks (100ms at 24kHz).
     private static let interChunkSilence = 2400
 
+    /// Minimum audio to keep before the first non-BOS token when trimming BOS output.
+    private static let minLeadingBOSPreroll = 960  // 40ms at 24kHz
+
+    /// Fast-speech floor for adaptive BOS preroll.
+    private static let minFastLeadingBOSPreroll = 720  // 30ms at 24kHz
+
+    /// Maximum audio to keep before the first non-BOS token when trimming BOS output.
+    private static let maxLeadingBOSPreroll = 2040  // 85ms at 24kHz
+
+    /// Fallback BOS preroll when no onset energy is detected.
+    private static let fallbackLeadingBOSPreroll = 1800  // 75ms at 24kHz
+
+    /// Tail of the BOS span scanned for onset energy.
+    private static let leadingBOSSearchWindow = 3000  // 125ms at 24kHz
+
+    /// RMS analysis window for adaptive BOS trimming.
+    private static let leadingBOSAnalysisWindow = 120  // 5ms at 24kHz
+
+    /// Small margin kept before detected onset so fade-in does not eat the transient.
+    private static let leadingBOSOnsetMargin = 120  // 5ms at 24kHz
+
     private enum Feature {
         static let inputIds = "input_ids"
         static let attentionMask = "attention_mask"
@@ -701,16 +722,98 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var samples = MLArrayHelpers.extractFloats(from: audio, maxCount: validSamples)
 
-        // Drop audio generated for the leading BOS token (token id 0). The model
-        // assigns it real duration frames and synthesizes a short voiced onset —
-        // audible as a schwa before unvoiced fricatives (e.g. "uh-Switch").
         if let leadingFrames = durations.first, leadingFrames > 0 {
             let leadSamples = min(leadingFrames * Self.hopSize, samples.count)
-            samples.removeFirst(leadSamples)
+            let trimSamples = Self.adaptiveLeadingBOSTrimSamples(
+                in: samples, leadSamples: leadSamples, speed: speed)
+            if trimSamples > 0 {
+                samples.removeFirst(trimSamples)
+            }
         }
 
         Self.removeTailArtifact(&samples)
         return (samples, durations)
+    }
+
+    /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
+    private static func adaptiveLeadingBOSTrimSamples(
+        in samples: [Float], leadSamples: Int, speed: Float
+    ) -> Int {
+        guard leadSamples > 0 else { return 0 }
+
+        let clampedLeadSamples = min(leadSamples, samples.count)
+        let speedScale = 1.0 / max(1.0, speed)
+        let scaledMinPreroll = max(
+            minFastLeadingBOSPreroll,
+            Int((Float(minLeadingBOSPreroll) * speedScale).rounded()))
+        let scaledMaxPreroll = max(
+            scaledMinPreroll,
+            Int((Float(maxLeadingBOSPreroll) * speedScale).rounded()))
+        let scaledFallbackPreroll = min(
+            scaledMaxPreroll,
+            max(scaledMinPreroll, Int((Float(fallbackLeadingBOSPreroll) * speedScale).rounded())))
+
+        let minPreroll = min(scaledMinPreroll, clampedLeadSamples)
+        let maxPreroll = min(scaledMaxPreroll, clampedLeadSamples)
+        let fallbackPreroll = min(scaledFallbackPreroll, clampedLeadSamples)
+        let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
+        let window = leadingBOSAnalysisWindow
+        guard clampedLeadSamples - searchStart >= window else {
+            return max(0, clampedLeadSamples - fallbackPreroll)
+        }
+
+        var rmsWindows: [(offset: Int, rms: Float)] = []
+        var maxRMS: Float = 0
+        var offset = searchStart
+        while offset + window <= clampedLeadSamples {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + window) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            let rms = sqrtf(sumSquares / Float(window))
+            rmsWindows.append((offset, rms))
+            maxRMS = max(maxRMS, rms)
+            offset += window
+        }
+
+        guard maxRMS > 0 else {
+            return max(0, clampedLeadSamples - minPreroll)
+        }
+
+        let baselineCount = min(5, rmsWindows.count)
+        let baselineRMS =
+            rmsWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
+            / Float(baselineCount)
+        let threshold = max(maxRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+
+        var onsetOffset: Int?
+        for index in rmsWindows.indices {
+            guard rmsWindows[index].rms >= threshold else { continue }
+
+            let lookaheadEnd = min(index + 5, rmsWindows.count)
+            var sustainedWindows = 0
+            for lookahead in index..<lookaheadEnd {
+                if rmsWindows[lookahead].rms >= threshold {
+                    sustainedWindows += 1
+                }
+            }
+
+            if sustainedWindows >= 3 {
+                onsetOffset = rmsWindows[index].offset
+                break
+            }
+        }
+
+        let preroll: Int
+        if let onsetOffset {
+            let detectedPreroll = clampedLeadSamples - onsetOffset + leadingBOSOnsetMargin
+            preroll = min(maxPreroll, max(minPreroll, detectedPreroll))
+        } else {
+            preroll = fallbackPreroll
+        }
+
+        return max(0, clampedLeadSamples - preroll)
     }
 
     /// Remove spurious spike artifacts from the tail of synthesized audio.

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -752,14 +752,15 @@ public final class KokoroEngine: @unchecked Sendable {
         let fallbackPreroll = min(leadingBOSOnsetMargin, clampedLeadSamples)
         let searchStart = max(0, clampedLeadSamples - leadingBOSSearchWindow)
         let window = leadingBOSAnalysisWindow
-        guard clampedLeadSamples - searchStart >= window else {
+        let analysisEnd = min(samples.count, clampedLeadSamples + 2 * window)
+        guard analysisEnd - searchStart >= window else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
         var rmsWindows: [(offset: Int, rms: Float)] = []
         var maxRMS: Float = 0
         var offset = searchStart
-        while offset + window <= clampedLeadSamples {
+        while offset + window <= analysisEnd {
             var sumSquares: Float = 0
             for i in offset..<(offset + window) {
                 let sample = samples[i]
@@ -783,6 +784,7 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {
+            guard rmsWindows[index].offset < clampedLeadSamples else { break }
             guard rmsWindows[index].rms >= threshold else { continue }
 
             let lookaheadEnd = min(index + 5, rmsWindows.count)

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -758,7 +758,6 @@ public final class KokoroEngine: @unchecked Sendable {
         }
 
         var rmsWindows: [(offset: Int, rms: Float)] = []
-        var maxRMS: Float = 0
         var offset = searchStart
         while offset + window <= analysisEnd {
             var sumSquares: Float = 0
@@ -768,19 +767,20 @@ public final class KokoroEngine: @unchecked Sendable {
             }
             let rms = sqrtf(sumSquares / Float(window))
             rmsWindows.append((offset, rms))
-            maxRMS = max(maxRMS, rms)
             offset += window
         }
 
-        guard maxRMS > 0 else {
+        let bosWindows = rmsWindows.filter { $0.offset < clampedLeadSamples }
+        let maxBOSRMS = bosWindows.reduce(Float(0)) { max($0, $1.rms) }
+        guard maxBOSRMS > 0 else {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let baselineCount = min(5, rmsWindows.count)
+        let baselineCount = min(5, bosWindows.count)
         let baselineRMS =
-            rmsWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
+            bosWindows.prefix(baselineCount).reduce(Float(0)) { $0 + $1.rms }
             / Float(baselineCount)
-        let threshold = max(maxRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
+        let threshold = max(maxBOSRMS * 0.10, baselineRMS * 8.0, Float(0.00002))
 
         var onsetOffset: Int?
         for index in rmsWindows.indices {

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -110,12 +110,12 @@ public final class KokoroEngine: @unchecked Sendable {
     /// Required windows above threshold within the lookahead to accept an onset.
     private static let leadingBOSOnsetSustainWindows = 3
 
-    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
-    /// Must cover the 50ms applyFades fade-out so the fade attenuates only EOS audio.
-    private static let minTrailingEOSPostroll = 1200  // 50ms at 24kHz
+    /// Length of the trailing fade-out applied by `applyFades` (50ms at 24kHz).
+    private static let fadeOutSamples = 1200
 
-    /// Fast-speech floor for adaptive EOS postroll. Same fade-coverage requirement.
-    private static let minFastTrailingEOSPostroll = 1200  // 50ms at 24kHz
+    /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
+    /// Must cover `fadeOutSamples` so the fade attenuates only EOS audio.
+    private static let minTrailingEOSPostroll = fadeOutSamples
 
     /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
     private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz
@@ -322,7 +322,7 @@ public final class KokoroEngine: @unchecked Sendable {
             var ramp: Float = 0
             var step = 1.0 / Float(fadeIn)
             vDSP_vrampmul(ptr, 1, &ramp, &step, ptr, 1, vDSP_Length(fadeIn))
-            let fadeOut = min(1200, buf.count)
+            let fadeOut = min(fadeOutSamples, buf.count)
             let fadeStart = buf.count - fadeOut
             ramp = 1.0
             step = -1.0 / Float(fadeOut)
@@ -780,6 +780,27 @@ public final class KokoroEngine: @unchecked Sendable {
         return (samples, durations)
     }
 
+    /// Compute per-window RMS over `samples[start..<end]` in non-overlapping `windowSize`
+    /// chunks. Trailing samples that don't fill a full window are dropped.
+    private static func rmsWindows(
+        in samples: [Float], from start: Int, to end: Int, windowSize: Int
+    ) -> [(offset: Int, rms: Float)] {
+        let capacity = max(0, (end - start) / windowSize)
+        var windows: [(offset: Int, rms: Float)] = []
+        windows.reserveCapacity(capacity)
+        var offset = start
+        while offset + windowSize <= end {
+            var sumSquares: Float = 0
+            for i in offset..<(offset + windowSize) {
+                let sample = samples[i]
+                sumSquares += sample * sample
+            }
+            windows.append((offset, sqrtf(sumSquares / Float(windowSize))))
+            offset += windowSize
+        }
+        return windows
+    }
+
     /// Choose how much of the leading BOS span to remove without cutting first-phoneme onset.
     static func adaptiveLeadingBOSTrimSamples(
         in samples: [Float], leadSamples: Int, speed: Float
@@ -807,20 +828,8 @@ public final class KokoroEngine: @unchecked Sendable {
             return max(0, clampedLeadSamples - fallbackPreroll)
         }
 
-        let windowCapacity = (analysisEnd - searchStart) / window
-        var rmsWindows: [(offset: Int, rms: Float)] = []
-        rmsWindows.reserveCapacity(windowCapacity)
-        var offset = searchStart
-        while offset + window <= analysisEnd {
-            var sumSquares: Float = 0
-            for i in offset..<(offset + window) {
-                let sample = samples[i]
-                sumSquares += sample * sample
-            }
-            let rms = sqrtf(sumSquares / Float(window))
-            rmsWindows.append((offset, rms))
-            offset += window
-        }
+        let rmsWindows = Self.rmsWindows(
+            in: samples, from: searchStart, to: analysisEnd, windowSize: window)
 
         var maxBOSRMS: Float = 0
         var baselineSum: Float = 0
@@ -870,10 +879,10 @@ public final class KokoroEngine: @unchecked Sendable {
     }
 
     /// Choose how much of the trailing EOS span to remove without cutting last-phoneme tail.
-    /// Mirrors `adaptiveLeadingBOSTrimSamples`: scans the EOS span for a sharp RMS drop
-    /// (≈12 dB) that marks the speech-tail → schwa transition, then trims from there
-    /// using a clamped postroll budget. Falls back to `minPostroll` when no drop is found
-    /// (uniformly silent EOS, e.g. voices with no audible trailing schwa).
+    /// Scans the EOS span for a sharp RMS drop (≈12 dB) that marks the speech-tail →
+    /// schwa transition, then trims from there using a clamped postroll budget. Falls
+    /// back to `minPostroll` when no drop is found (uniformly silent EOS, e.g. voices
+    /// with no audible trailing schwa).
     static func adaptiveTrailingEOSTrimSamples(
         in samples: [Float], trailSamples: Int, speed: Float
     ) -> Int {
@@ -881,15 +890,10 @@ public final class KokoroEngine: @unchecked Sendable {
 
         let clampedTrailSamples = min(trailSamples, samples.count)
         let speedScale = 1.0 / max(1.0, speed)
-        let scaledMinPostroll = max(
-            minFastTrailingEOSPostroll,
-            Int((Float(minTrailingEOSPostroll) * speedScale).rounded()))
-        let scaledMaxPostroll = max(
-            scaledMinPostroll,
-            Int((Float(maxTrailingEOSPostroll) * speedScale).rounded()))
-
-        let minPostroll = min(scaledMinPostroll, clampedTrailSamples)
-        let maxPostroll = min(scaledMaxPostroll, clampedTrailSamples)
+        let minPostroll = min(minTrailingEOSPostroll, clampedTrailSamples)
+        let maxPostroll = min(
+            max(minPostroll, Int((Float(maxTrailingEOSPostroll) * speedScale).rounded())),
+            clampedTrailSamples)
         let eosStart = samples.count - clampedTrailSamples
         let window = leadingBOSAnalysisWindow
         // Look back 2 windows before EOS to anchor the drop comparison in real speech tail.
@@ -899,19 +903,8 @@ public final class KokoroEngine: @unchecked Sendable {
             return max(0, clampedTrailSamples - minPostroll)
         }
 
-        let windowCapacity = (samples.count - analysisStart) / window
-        var rmsWindows: [(offset: Int, rms: Float)] = []
-        rmsWindows.reserveCapacity(windowCapacity)
-        var offset = analysisStart
-        while offset + window <= samples.count {
-            var sumSquares: Float = 0
-            for i in offset..<(offset + window) {
-                let sample = samples[i]
-                sumSquares += sample * sample
-            }
-            rmsWindows.append((offset, sqrtf(sumSquares / Float(window))))
-            offset += window
-        }
+        let rmsWindows = Self.rmsWindows(
+            in: samples, from: analysisStart, to: samples.count, windowSize: window)
 
         var boundaryOffset: Int?
         for index in 1..<rmsWindows.count {

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -111,10 +111,11 @@ public final class KokoroEngine: @unchecked Sendable {
     private static let leadingBOSOnsetSustainWindows = 3
 
     /// Minimum audio to keep after the last non-EOS token when trimming EOS output.
-    private static let minTrailingEOSPostroll = 960  // 40ms at 24kHz
+    /// Must cover the 50ms applyFades fade-out so the fade attenuates only EOS audio.
+    private static let minTrailingEOSPostroll = 1200  // 50ms at 24kHz
 
-    /// Fast-speech floor for adaptive EOS postroll.
-    private static let minFastTrailingEOSPostroll = 720  // 30ms at 24kHz
+    /// Fast-speech floor for adaptive EOS postroll. Same fade-coverage requirement.
+    private static let minFastTrailingEOSPostroll = 1200  // 50ms at 24kHz
 
     /// Maximum audio to keep after the last non-EOS token when trimming EOS output.
     private static let maxTrailingEOSPostroll = 2040  // 85ms at 24kHz

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -1,0 +1,40 @@
+import Testing
+
+@testable import KokoroCoreML
+
+@Suite("KokoroEngine BOS trim")
+struct KokoroEngineBOSTrimTests {
+    @Test("Fallback trims short BOS spans instead of keeping the whole allocation")
+    func fallbackTrimsShortBOSSpans() {
+        let onsetMarginSamples = Int(Float(KokoroEngine.sampleRate) * 0.005)
+
+        for leadingFrames in 1...3 {
+            let leadSamples = leadingFrames * KokoroEngine.hopSize
+            let samples = [Float](repeating: 0.01, count: leadSamples + KokoroEngine.hopSize)
+            let silentSamples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+
+            let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+                in: samples, leadSamples: leadSamples, speed: 1.0)
+            let silentTrimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+                in: silentSamples, leadSamples: leadSamples, speed: 1.0)
+
+            #expect(trimSamples == leadSamples - onsetMarginSamples)
+            #expect(silentTrimSamples == leadSamples - onsetMarginSamples)
+        }
+    }
+
+    @Test("Detected onset keeps adaptive preroll before the first phoneme")
+    func detectedOnsetKeepsAdaptivePreroll() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 960
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<leadSamples {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == onsetOffset - 120)
+    }
+}

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -103,8 +103,8 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720,
-        // clamped to [minPostroll=960, maxPostroll=2040] → 960.
+        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720;
+        // max(minPostroll=960, 720) wins → postroll = 960.
         #expect(trimSamples == trailSamples - 960)
     }
 

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -37,4 +37,19 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == onsetOffset - 120)
     }
+
+    @Test("Boundary-near onset can use post-BOS samples for sustain")
+    func boundaryNearOnsetUsesPostBOSSustain() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 120
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<samples.count {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == leadSamples - 960)
+    }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -70,4 +70,78 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == leadSamples - 960)
     }
+
+    @Test("EOS fallback preserves minPostroll when no drop is detected")
+    func eosFallbackPreservesMinPostroll() {
+        let trailSamples = 4 * KokoroEngine.hopSize
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let uniform = [Float](repeating: 0.01, count: totalSamples)
+        let silent = [Float](repeating: 0, count: totalSamples)
+
+        let uniformTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: uniform, trailSamples: trailSamples, speed: 1.0)
+        let silentTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: silent, trailSamples: trailSamples, speed: 1.0)
+
+        // No drop → fallback minPostroll = 40ms = 960 samples.
+        #expect(uniformTrim == trailSamples - 960)
+        #expect(silentTrim == trailSamples - 960)
+    }
+
+    @Test("EOS detected drop expands postroll up to maxPostroll")
+    func eosDetectedDropAdaptsPostroll() {
+        let trailSamples = 8 * KokoroEngine.hopSize  // 4800 samples (200ms)
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let eosStart = totalSamples - trailSamples
+        // Drop boundary at +5 windows (600 samples = 25ms) into EOS.
+        let dropAt = eosStart + 5 * 120
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720,
+        // clamped to [minPostroll=960, maxPostroll=2040] → 960.
+        #expect(trimSamples == trailSamples - 960)
+    }
+
+    @Test("EOS deep drop selects detected postroll over minimum")
+    func eosDeepDropUsesDetectedPostroll() {
+        let trailSamples = 12 * KokoroEngine.hopSize  // 7200 samples (300ms)
+        let totalSamples = trailSamples + KokoroEngine.hopSize
+        let eosStart = totalSamples - trailSamples
+        // Drop boundary at +10 windows (1200 samples = 50ms) into EOS.
+        let dropAt = eosStart + 10 * 120
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        // detectedPostroll = 1200 + 120 = 1320, between min(960) and max(2040) → 1320.
+        #expect(trimSamples == trailSamples - 1320)
+    }
+
+    @Test("Pre-EOS drops do not trigger boundary detection")
+    func preEOSDropIgnored() {
+        let trailSamples = 4 * KokoroEngine.hopSize
+        let totalSamples = trailSamples + 4 * KokoroEngine.hopSize  // extra speech tail
+        let eosStart = totalSamples - trailSamples
+        // Drop happens entirely BEFORE EOS — should fall back to minPostroll.
+        let dropAt = eosStart - 240
+        var samples = [Float](repeating: 0.01, count: totalSamples)
+        for index in 0..<dropAt {
+            samples[index] = 0.1
+        }
+
+        let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
+            in: samples, trailSamples: trailSamples, speed: 1.0)
+
+        #expect(trimSamples == trailSamples - 960)
+    }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -83,9 +83,9 @@ struct KokoroEngineBOSTrimTests {
         let silentTrim = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: silent, trailSamples: trailSamples, speed: 1.0)
 
-        // No drop → fallback minPostroll = 40ms = 960 samples.
-        #expect(uniformTrim == trailSamples - 960)
-        #expect(silentTrim == trailSamples - 960)
+        // No drop → fallback minPostroll = 50ms = 1200 samples.
+        #expect(uniformTrim == trailSamples - 1200)
+        #expect(silentTrim == trailSamples - 1200)
     }
 
     @Test("EOS detected drop expands postroll up to maxPostroll")
@@ -104,8 +104,8 @@ struct KokoroEngineBOSTrimTests {
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
         // detectedPostroll = (dropAt - eosStart) + 120 margin = 600 + 120 = 720;
-        // max(minPostroll=960, 720) wins → postroll = 960.
-        #expect(trimSamples == trailSamples - 960)
+        // max(minPostroll=1200, 720) wins → postroll = 1200.
+        #expect(trimSamples == trailSamples - 1200)
     }
 
     @Test("EOS deep drop selects detected postroll over minimum")
@@ -113,8 +113,8 @@ struct KokoroEngineBOSTrimTests {
         let trailSamples = 12 * KokoroEngine.hopSize  // 7200 samples (300ms)
         let totalSamples = trailSamples + KokoroEngine.hopSize
         let eosStart = totalSamples - trailSamples
-        // Drop boundary at +10 windows (1200 samples = 50ms) into EOS.
-        let dropAt = eosStart + 10 * 120
+        // Drop boundary at +12 windows (1440 samples = 60ms) into EOS.
+        let dropAt = eosStart + 12 * 120
         var samples = [Float](repeating: 0.01, count: totalSamples)
         for index in 0..<dropAt {
             samples[index] = 0.1
@@ -123,8 +123,8 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        // detectedPostroll = 1200 + 120 = 1320, between min(960) and max(2040) → 1320.
-        #expect(trimSamples == trailSamples - 1320)
+        // detectedPostroll = 1440 + 120 = 1560, between min(1200) and max(2040) → 1560.
+        #expect(trimSamples == trailSamples - 1560)
     }
 
     @Test("Pre-EOS drops do not trigger boundary detection")
@@ -142,6 +142,6 @@ struct KokoroEngineBOSTrimTests {
         let trimSamples = KokoroEngine.adaptiveTrailingEOSTrimSamples(
             in: samples, trailSamples: trailSamples, speed: 1.0)
 
-        #expect(trimSamples == trailSamples - 960)
+        #expect(trimSamples == trailSamples - 1200)
     }
 }

--- a/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
+++ b/Tests/KokoroCoreMLTests/KokoroEngineBOSTrimTests.swift
@@ -52,4 +52,22 @@ struct KokoroEngineBOSTrimTests {
 
         #expect(trimSamples == leadSamples - 960)
     }
+
+    @Test("Post-BOS peaks do not raise the onset threshold")
+    func postBOSPeaksDoNotRaiseOnsetThreshold() {
+        let leadSamples = 4 * KokoroEngine.hopSize
+        let onsetOffset = leadSamples - 240
+        var samples = [Float](repeating: 0, count: leadSamples + KokoroEngine.hopSize)
+        for index in onsetOffset..<leadSamples {
+            samples[index] = 0.02
+        }
+        for index in leadSamples..<samples.count {
+            samples[index] = 0.5
+        }
+
+        let trimSamples = KokoroEngine.adaptiveLeadingBOSTrimSamples(
+            in: samples, leadSamples: leadSamples, speed: 1.0)
+
+        #expect(trimSamples == leadSamples - 960)
+    }
 }

--- a/scripts/debug_pred_dur_diff.py
+++ b/scripts/debug_pred_dur_diff.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Diff predicted token durations between patched-PyTorch and CoreML.
+
+Verifies whether the duration predictor produces stable per-token durations
+across pad lengths after the CoreMLPackedBidirLSTM patch lands. If durations
+are stable across totals (real_n, 8, 16, 24, 32, 64, 100), the export is now
+length-aware. If they drift, the patch is incomplete.
+
+Usage:
+    .venv/bin/python scripts/debug_pred_dur_diff.py [--coreml] [--voice bf_lily]
+
+By default runs PyTorch only. Pass --coreml to also load the deployed CoreML
+frontend and compare side by side.
+"""
+import argparse
+import os
+import sys
+
+import numpy as np
+import torch
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+
+from export_coreml import KokoroModelA, NUM_HARMONICS, load_kokoro_model  # noqa: E402
+from reference import (  # noqa: E402
+    patch_pack_padded_sequence, patch_sinegen_for_export,
+)
+
+DEFAULT_FRONTEND = os.path.expanduser(
+    "~/Library/Application Support/com.operator.app/models/kokoro/kokoro_frontend.mlmodelc"
+)
+
+
+def make_inputs(token_ids, total_n):
+    real_n = len(token_ids)
+    ids = np.zeros((1, total_n), dtype=np.int32)
+    mask = np.zeros((1, total_n), dtype=np.int32)
+    ids[0, :real_n] = np.array(token_ids, dtype=np.int32)
+    mask[0, :real_n] = 1
+    return ids, mask
+
+
+def run_torch(frontend, token_ids, total_n, ref_s):
+    ids_np, mask_np = make_inputs(token_ids, total_n)
+    with torch.no_grad():
+        *_, pred_dur = frontend(
+            torch.from_numpy(ids_np).long(),
+            torch.from_numpy(mask_np).long(),
+            ref_s,
+            torch.tensor([1.0]),
+            torch.zeros(1, NUM_HARMONICS),
+        )
+    return pred_dur.flatten().cpu().numpy()
+
+
+def run_coreml(fe, token_ids, total_n, ref_s):
+    ids_np, mask_np = make_inputs(token_ids, total_n)
+    out = fe.predict({
+        "input_ids": ids_np,
+        "attention_mask": mask_np,
+        "ref_s": ref_s.detach().numpy().astype(np.float32),
+        "speed": np.array([1.0], dtype=np.float32),
+        "random_phases": np.zeros((1, NUM_HARMONICS), dtype=np.float32),
+    })
+    return out["pred_dur_clamped"].flatten()
+
+
+def tokenize(text, pipeline):
+    """Convert text → token id sequence using the pipeline's G2P + vocab."""
+    _, tokens = pipeline.g2p(text)
+    phonemes = "".join(t.phonemes or "" for t in tokens)
+    ids = [pipeline.model.vocab[c] for c in phonemes if c in pipeline.model.vocab]
+    return [0] + ids + [0]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--coreml", action="store_true")
+    parser.add_argument("--frontend-path", default=DEFAULT_FRONTEND)
+    parser.add_argument("--voice", default="bf_lily")
+    parser.add_argument(
+        "--texts", nargs="+",
+        default=["4.", "Beauty.", "Switch", "Hello world."])
+    args = parser.parse_args()
+
+    pipeline, model = load_kokoro_model()
+    set_phases = patch_sinegen_for_export(model)
+    patch_pack_padded_sequence()
+
+    fe_torch = KokoroModelA(model, 100, 267000, set_phases).eval()
+
+    fe_coreml = None
+    if args.coreml:
+        import coremltools as ct
+        fe_coreml = ct.models.MLModel(
+            args.frontend_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+
+    voice = pipeline.load_voice(args.voice)
+
+    for text in args.texts:
+        token_ids = tokenize(text, pipeline)
+        real_n = len(token_ids)
+        ref_s = voice[real_n - 1]
+        if ref_s.dim() == 1:
+            ref_s = ref_s.unsqueeze(0)
+
+        totals = sorted({real_n, 8, 16, 24, 32, 64, 100})
+        totals = [n for n in totals if n >= real_n]
+
+        print(f"\n{text!r} real_n={real_n} ids={token_ids}")
+        for total_n in totals:
+            pt = run_torch(fe_torch, token_ids, total_n, ref_s)
+            line = (
+                f"  N={total_n:3d}  pt={pt[:real_n].astype(int).tolist()} "
+                f"sum={int(pt[:real_n].sum())}"
+            )
+            if fe_coreml is not None:
+                cm = run_coreml(fe_coreml, token_ids, total_n, ref_s)
+                line += (
+                    f" | cm={cm[:real_n].astype(int).tolist()} "
+                    f"sum={int(cm[:real_n].sum())}"
+                )
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/debug_pred_dur_diff.py
+++ b/scripts/debug_pred_dur_diff.py
@@ -101,7 +101,9 @@ def main():
     for text in args.texts:
         token_ids = tokenize(text, pipeline)
         real_n = len(token_ids)
-        ref_s = voice[real_n - 1]
+        # Match pipeline.py: pack[len(ps)-1] where ps is the phoneme string
+        # (token_ids minus the BOS/EOS bracketing). real_n = len(ps) + 2.
+        ref_s = voice[real_n - 3]
         if ref_s.dim() == 1:
             ref_s = ref_s.unsqueeze(0)
 

--- a/scripts/debug_pred_dur_diff.py
+++ b/scripts/debug_pred_dur_diff.py
@@ -22,7 +22,9 @@ import torch
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, SCRIPT_DIR)
 
-from export_coreml import KokoroModelA, NUM_HARMONICS, load_kokoro_model  # noqa: E402
+from export_coreml import (  # noqa: E402
+    KokoroModelA, NUM_HARMONICS, _tokenize, load_kokoro_model,
+)
 from reference import (  # noqa: E402
     patch_pack_padded_sequence, patch_sinegen_for_export,
 )
@@ -66,13 +68,6 @@ def run_coreml(fe, token_ids, total_n, ref_s):
     return out["pred_dur_clamped"].flatten()
 
 
-def tokenize(text, pipeline):
-    _, tokens = pipeline.g2p(text)
-    phonemes = "".join(t.phonemes or "" for t in tokens)
-    ids = [pipeline.model.vocab[c] for c in phonemes if c in pipeline.model.vocab]
-    return [0] + ids + [0]
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--coreml", action="store_true")
@@ -102,7 +97,7 @@ def main():
     voice = pipeline.load_voice(args.voice)
 
     for text in args.texts:
-        token_ids = tokenize(text, pipeline)
+        token_ids = _tokenize(text, pipeline)
         real_n = len(token_ids)
         # Match pipeline.py: pack[len(ps)-1] where ps is the phoneme string
         # (token_ids minus the BOS/EOS bracketing). real_n = len(ps) + 2.

--- a/scripts/debug_pred_dur_diff.py
+++ b/scripts/debug_pred_dur_diff.py
@@ -67,7 +67,6 @@ def run_coreml(fe, token_ids, total_n, ref_s):
 
 
 def tokenize(text, pipeline):
-    """Convert text → token id sequence using the pipeline's G2P + vocab."""
     _, tokens = pipeline.g2p(text)
     phonemes = "".join(t.phonemes or "" for t in tokens)
     ids = [pipeline.model.vocab[c] for c in phonemes if c in pipeline.model.vocab]

--- a/scripts/debug_pred_dur_diff.py
+++ b/scripts/debug_pred_dur_diff.py
@@ -92,8 +92,12 @@ def main():
     fe_coreml = None
     if args.coreml:
         import coremltools as ct
-        fe_coreml = ct.models.MLModel(
-            args.frontend_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+        if args.frontend_path.endswith(".mlmodelc"):
+            fe_coreml = ct.models.CompiledMLModel(
+                args.frontend_path, compute_units=ct.ComputeUnit.CPU_ONLY)
+        else:
+            fe_coreml = ct.models.MLModel(
+                args.frontend_path, compute_units=ct.ComputeUnit.CPU_ONLY)
 
     voice = pipeline.load_voice(args.voice)
 

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -382,7 +382,6 @@ class CoreMLPackedBidirLSTM(nn.Module):
         copy(self.rev, "_reverse")
 
     def forward(self, x, lengths, pad_mask):
-        # x: [B, T, C], lengths: [B] long, pad_mask: [B, T] bool (True = padded)
         valid = (~pad_mask).to(x.dtype).unsqueeze(-1)
         x = x * valid
 
@@ -411,7 +410,6 @@ class CoreMLTextEncoder(nn.Module):
         self.lstm = CoreMLPackedBidirLSTM(src.lstm)
 
     def forward(self, x, input_lengths, m):
-        # m: [B, T] bool, True = padded position.
         x = self.embedding(x)
         x = x.transpose(1, 2)
         m1 = m.unsqueeze(1)
@@ -444,7 +442,6 @@ class CoreMLDurationEncoder(nn.Module):
         self.sty_dim = src.sty_dim
 
     def forward(self, x, style, text_lengths, m):
-        # m: [B, T] bool, True = padded.
         masks = m
         x = x.permute(2, 0, 1)
         s = style.expand(x.shape[0], x.shape[1], -1)

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -430,7 +430,6 @@ class CoreMLDurationEncoder(nn.Module):
     def __init__(self, src):
         super().__init__()
         from kokoro.modules import AdaLayerNorm
-        self.AdaLayerNorm = AdaLayerNorm
         self.lstms = nn.ModuleList()
         for block in src.lstms:
             if isinstance(block, AdaLayerNorm):
@@ -442,6 +441,7 @@ class CoreMLDurationEncoder(nn.Module):
         self.sty_dim = src.sty_dim
 
     def forward(self, x, style, text_lengths, m):
+        from kokoro.modules import AdaLayerNorm
         masks = m
         x = x.permute(2, 0, 1)
         s = style.expand(x.shape[0], x.shape[1], -1)
@@ -450,7 +450,7 @@ class CoreMLDurationEncoder(nn.Module):
         x = x.transpose(0, 1)
         x = x.transpose(-1, -2)
         for block in self.lstms:
-            if isinstance(block, self.AdaLayerNorm):
+            if isinstance(block, AdaLayerNorm):
                 x = block(x.transpose(-1, -2), style).transpose(-1, -2)
                 x = torch.cat([x, s.permute(1, 2, 0)], axis=1)
                 x = x.masked_fill(masks.unsqueeze(-1).transpose(-1, -2), 0.0)
@@ -478,9 +478,15 @@ class KokoroModelA(nn.Module):
 
         self.bert = model.bert
         self.bert_encoder = model.bert_encoder
-        self.predictor = model.predictor
+        # Length-aware substitutes for the bidir LSTM sites in StyleTTS2.
+        # See CoreMLPackedBidirLSTM block comment for the export-pipeline
+        # rationale. Holding only the predictor sub-modules we still call
+        # avoids double-registering the original predictor.text_encoder /
+        # predictor.lstm weights in the traced state_dict.
         self.predictor_text_encoder = CoreMLDurationEncoder(model.predictor.text_encoder)
         self.predictor_duration_lstm = CoreMLPackedBidirLSTM(model.predictor.lstm)
+        self.predictor_duration_proj = model.predictor.duration_proj
+        self.predictor_F0Ntrain = model.predictor.F0Ntrain
         self.text_encoder = CoreMLTextEncoder(model.text_encoder)
         self.gen_frontend = GeneratorFrontEnd(model.decoder.generator)
 
@@ -512,7 +518,7 @@ class KokoroModelA(nn.Module):
 
         d = self.predictor_text_encoder(d_en, s, input_lengths, text_mask)
         x = self.predictor_duration_lstm(d, input_lengths, text_mask)
-        duration = self.predictor.duration_proj(x)
+        duration = self.predictor_duration_proj(x)
         duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
         pred_dur = torch.round(duration).clamp(min=1).long()
         pred_dur = pred_dur * attention_mask.long()
@@ -530,7 +536,7 @@ class KokoroModelA(nn.Module):
         ).float()
 
         en = d.transpose(-1, -2) @ pred_aln_trg
-        F0_pred, N_pred = self.predictor.F0Ntrain(en, s)
+        F0_pred, N_pred = self.predictor_F0Ntrain(en, s)
 
         t_en = self.text_encoder(input_ids, input_lengths, text_mask)
         asr = t_en @ pred_aln_trg

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -343,6 +343,129 @@ def load_kokoro_model():
 
 
 # ---------------------------------------------------------------------------
+# CoreML-friendly length-aware bidirectional LSTM
+# ---------------------------------------------------------------------------
+# StyleTTS2's text encoder, duration encoder, and prosody predictor all use
+# pack_padded_sequence around bidirectional LSTMs. CoreML cannot convert
+# pack_padded_sequence, so the export historically patched it to a no-op
+# (reference.patch_pack_padded_sequence). That removed length-awareness — the
+# reverse direction of every bidir LSTM consumed pad tokens before reaching the
+# real prefix, contaminating real-token hidden states. Symptom: short utterances
+# get distorted durations.
+#
+# CoreMLPackedBidirLSTM splits a bidir LSTM into two unidirectional LSTMs and
+# reverses only the valid prefix using arange + where + gather — all static ops
+# that survive jit.trace + coremltools convert. Math is equivalent to the
+# original packed bidir LSTM under right-padding (our case).
+class CoreMLPackedBidirLSTM(nn.Module):
+    def __init__(self, src):
+        super().__init__()
+        if not (src.bidirectional and src.num_layers == 1 and src.batch_first):
+            raise ValueError(
+                "CoreMLPackedBidirLSTM expects a 1-layer bidirectional batch_first LSTM")
+        self.hidden_size = src.hidden_size
+        self.fwd = nn.LSTM(
+            src.input_size, src.hidden_size, 1,
+            batch_first=True, bias=src.bias)
+        self.rev = nn.LSTM(
+            src.input_size, src.hidden_size, 1,
+            batch_first=True, bias=src.bias)
+
+        def copy(dst, suffix):
+            for name in ("weight_ih_l0", "weight_hh_l0"):
+                getattr(dst, name).data.copy_(getattr(src, name + suffix).data)
+            if src.bias:
+                for name in ("bias_ih_l0", "bias_hh_l0"):
+                    getattr(dst, name).data.copy_(getattr(src, name + suffix).data)
+
+        copy(self.fwd, "")
+        copy(self.rev, "_reverse")
+
+    def forward(self, x, lengths, pad_mask):
+        # x: [B, T, C], lengths: [B] long, pad_mask: [B, T] bool (True = padded)
+        valid = (~pad_mask).to(x.dtype).unsqueeze(-1)
+        x = x * valid
+
+        y_f, _ = self.fwd(x)
+
+        b, t, c = x.shape
+        idx = torch.arange(t, device=x.device, dtype=lengths.dtype).unsqueeze(0).expand(b, t)
+        l = lengths.unsqueeze(1)
+        rev_idx = torch.where(idx < l, l - 1 - idx, idx).to(torch.long)
+
+        x_rev = torch.gather(x, 1, rev_idx.unsqueeze(-1).expand(b, t, c))
+        y_rev_seq, _ = self.rev(x_rev)
+        y_r = torch.gather(
+            y_rev_seq, 1, rev_idx.unsqueeze(-1).expand(b, t, self.hidden_size))
+
+        return torch.cat([y_f, y_r], dim=-1) * valid
+
+
+class CoreMLTextEncoder(nn.Module):
+    """Length-aware replacement for kokoro.modules.TextEncoder."""
+
+    def __init__(self, src):
+        super().__init__()
+        self.embedding = src.embedding
+        self.cnn = src.cnn
+        self.lstm = CoreMLPackedBidirLSTM(src.lstm)
+
+    def forward(self, x, input_lengths, m):
+        # m: [B, T] bool, True = padded position.
+        x = self.embedding(x)
+        x = x.transpose(1, 2)
+        m1 = m.unsqueeze(1)
+        x = x.masked_fill(m1, 0.0)
+        for c in self.cnn:
+            x = c(x)
+            x = x.masked_fill(m1, 0.0)
+        x = x.transpose(1, 2)
+        x = self.lstm(x, input_lengths, m)
+        x = x.transpose(-1, -2)
+        x = x.masked_fill(m1, 0.0)
+        return x
+
+
+class CoreMLDurationEncoder(nn.Module):
+    """Length-aware replacement for kokoro.modules.DurationEncoder."""
+
+    def __init__(self, src):
+        super().__init__()
+        from kokoro.modules import AdaLayerNorm
+        self.AdaLayerNorm = AdaLayerNorm
+        self.lstms = nn.ModuleList()
+        for block in src.lstms:
+            if isinstance(block, AdaLayerNorm):
+                self.lstms.append(block)
+            else:
+                self.lstms.append(CoreMLPackedBidirLSTM(block))
+        self.dropout = src.dropout
+        self.d_model = src.d_model
+        self.sty_dim = src.sty_dim
+
+    def forward(self, x, style, text_lengths, m):
+        # m: [B, T] bool, True = padded.
+        masks = m
+        x = x.permute(2, 0, 1)
+        s = style.expand(x.shape[0], x.shape[1], -1)
+        x = torch.cat([x, s], axis=-1)
+        x = x.masked_fill(masks.unsqueeze(-1).transpose(0, 1), 0.0)
+        x = x.transpose(0, 1)
+        x = x.transpose(-1, -2)
+        for block in self.lstms:
+            if isinstance(block, self.AdaLayerNorm):
+                x = block(x.transpose(-1, -2), style).transpose(-1, -2)
+                x = torch.cat([x, s.permute(1, 2, 0)], axis=1)
+                x = x.masked_fill(masks.unsqueeze(-1).transpose(-1, -2), 0.0)
+            else:
+                x = x.transpose(-1, -2)
+                x = block(x, text_lengths, m)
+                x = F.dropout(x, p=self.dropout, training=False)
+                x = x.transpose(-1, -2)
+        return x.transpose(-1, -2)
+
+
+# ---------------------------------------------------------------------------
 # Split pipeline wrappers for export
 # ---------------------------------------------------------------------------
 class KokoroModelA(nn.Module):
@@ -359,7 +482,9 @@ class KokoroModelA(nn.Module):
         self.bert = model.bert
         self.bert_encoder = model.bert_encoder
         self.predictor = model.predictor
-        self.text_encoder = model.text_encoder
+        self.predictor_text_encoder = CoreMLDurationEncoder(model.predictor.text_encoder)
+        self.predictor_duration_lstm = CoreMLPackedBidirLSTM(model.predictor.lstm)
+        self.text_encoder = CoreMLTextEncoder(model.text_encoder)
         self.gen_frontend = GeneratorFrontEnd(model.decoder.generator)
 
     def forward(self, input_ids, attention_mask, ref_s, speed, random_phases):
@@ -388,8 +513,8 @@ class KokoroModelA(nn.Module):
 
         s = ref_s[:, S_CONTENT_DIM:]
 
-        d = self.predictor.text_encoder(d_en, s, input_lengths, text_mask)
-        x, _ = self.predictor.lstm(d)
+        d = self.predictor_text_encoder(d_en, s, input_lengths, text_mask)
+        x = self.predictor_duration_lstm(d, input_lengths, text_mask)
         duration = self.predictor.duration_proj(x)
         duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
         pred_dur = torch.round(duration).clamp(min=1).long()

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -354,9 +354,9 @@ def load_kokoro_model():
 # get distorted durations.
 #
 # CoreMLPackedBidirLSTM splits a bidir LSTM into two unidirectional LSTMs and
-# reverses only the valid prefix using arange + where + gather — all static ops
-# that survive jit.trace + coremltools convert. Math is equivalent to the
-# original packed bidir LSTM under right-padding (our case).
+# reverses only the valid prefix via a permutation matmul — all static ops that
+# survive jit.trace + coremltools convert. Math is equivalent to the original
+# packed bidir LSTM under right-padding (our case).
 class CoreMLPackedBidirLSTM(nn.Module):
     def __init__(self, src):
         super().__init__()
@@ -394,13 +394,12 @@ class CoreMLPackedBidirLSTM(nn.Module):
         # carries shape forward cleanly. The permutation matrix selects
         # x[rev_idx[i]] for each output position i, where rev_idx flips only
         # the valid prefix (positions 0..L-1) and leaves pads in place. The
-        # same permutation undoes itself, so we use it for both directions.
-        b, t, c = x.shape
-        idx = torch.arange(t, device=x.device, dtype=lengths.dtype).unsqueeze(0).expand(b, t)
+        # permutation is its own inverse, so we use it for both directions.
+        t = x.shape[1]
+        pos = torch.arange(t, device=x.device, dtype=lengths.dtype)
         l = lengths.unsqueeze(1)
-        rev_idx = torch.where(idx < l, l - 1 - idx, idx)
-        positions = torch.arange(t, device=x.device, dtype=rev_idx.dtype).unsqueeze(0)
-        perm = (positions.unsqueeze(0) == rev_idx.unsqueeze(-1)).to(x.dtype)
+        rev_idx = torch.where(pos < l, l - 1 - pos, pos)
+        perm = (pos == rev_idx.unsqueeze(-1)).to(x.dtype)
 
         x_rev = torch.matmul(perm, x)
         y_rev_seq, _ = self.rev(x_rev)

--- a/scripts/export_coreml.py
+++ b/scripts/export_coreml.py
@@ -387,15 +387,24 @@ class CoreMLPackedBidirLSTM(nn.Module):
 
         y_f, _ = self.fwd(x)
 
+        # Length-aware reverse via permutation-matrix matmul.
+        # gather_along_axis on dynamic shapes loses output shape info in
+        # coremltools (becomes `tensor<fp32, [?, ?, ?]>`) which prevents the
+        # downstream LSTM from compiling (model-load error -14). matmul
+        # carries shape forward cleanly. The permutation matrix selects
+        # x[rev_idx[i]] for each output position i, where rev_idx flips only
+        # the valid prefix (positions 0..L-1) and leaves pads in place. The
+        # same permutation undoes itself, so we use it for both directions.
         b, t, c = x.shape
         idx = torch.arange(t, device=x.device, dtype=lengths.dtype).unsqueeze(0).expand(b, t)
         l = lengths.unsqueeze(1)
-        rev_idx = torch.where(idx < l, l - 1 - idx, idx).to(torch.long)
+        rev_idx = torch.where(idx < l, l - 1 - idx, idx)
+        positions = torch.arange(t, device=x.device, dtype=rev_idx.dtype).unsqueeze(0)
+        perm = (positions.unsqueeze(0) == rev_idx.unsqueeze(-1)).to(x.dtype)
 
-        x_rev = torch.gather(x, 1, rev_idx.unsqueeze(-1).expand(b, t, c))
+        x_rev = torch.matmul(perm, x)
         y_rev_seq, _ = self.rev(x_rev)
-        y_r = torch.gather(
-            y_rev_seq, 1, rev_idx.unsqueeze(-1).expand(b, t, self.hidden_size))
+        y_r = torch.matmul(perm, y_rev_seq)
 
         return torch.cat([y_f, y_r], dim=-1) * valid
 
@@ -478,15 +487,15 @@ class KokoroModelA(nn.Module):
 
         self.bert = model.bert
         self.bert_encoder = model.bert_encoder
-        # Length-aware substitutes for the bidir LSTM sites in StyleTTS2.
-        # See CoreMLPackedBidirLSTM block comment for the export-pipeline
-        # rationale. Holding only the predictor sub-modules we still call
-        # avoids double-registering the original predictor.text_encoder /
-        # predictor.lstm weights in the traced state_dict.
+        # Hold the whole predictor so jit registers all its sub-modules
+        # (predictor.shared / .F0 / .N / .F0_proj / .N_proj are reached via
+        # self.predictor.F0Ntrain in forward). The text_encoder and lstm
+        # inside model.predictor are bypassed at runtime by the CoreML*
+        # wrappers below — their weights are double-registered in state_dict
+        # but never traced.
+        self.predictor = model.predictor
         self.predictor_text_encoder = CoreMLDurationEncoder(model.predictor.text_encoder)
         self.predictor_duration_lstm = CoreMLPackedBidirLSTM(model.predictor.lstm)
-        self.predictor_duration_proj = model.predictor.duration_proj
-        self.predictor_F0Ntrain = model.predictor.F0Ntrain
         self.text_encoder = CoreMLTextEncoder(model.text_encoder)
         self.gen_frontend = GeneratorFrontEnd(model.decoder.generator)
 
@@ -518,7 +527,7 @@ class KokoroModelA(nn.Module):
 
         d = self.predictor_text_encoder(d_en, s, input_lengths, text_mask)
         x = self.predictor_duration_lstm(d, input_lengths, text_mask)
-        duration = self.predictor_duration_proj(x)
+        duration = self.predictor.duration_proj(x)
         duration = torch.sigmoid(duration).sum(dim=-1) / speed[0]
         pred_dur = torch.round(duration).clamp(min=1).long()
         pred_dur = pred_dur * attention_mask.long()
@@ -536,7 +545,7 @@ class KokoroModelA(nn.Module):
         ).float()
 
         en = d.transpose(-1, -2) @ pred_aln_trg
-        F0_pred, N_pred = self.predictor_F0Ntrain(en, s)
+        F0_pred, N_pred = self.predictor.F0Ntrain(en, s)
 
         t_en = self.text_encoder(input_ids, input_lengths, text_mask)
         asr = t_en @ pred_aln_trg


### PR DESCRIPTION
## Summary

Restores length-awareness to the StyleTTS2 bidirectional LSTMs in `scripts/export_coreml.py`. The dynamic CoreML export historically patched `pack_padded_sequence` to a no-op (CoreML can't convert it), which let pad-token states contaminate real-token hidden states in the duration predictor. Symptom: per-token `pred_dur` for "Switch" drops from sum=47 (correct) at N=7 to sum=27 at N=16 once any padding is present.

## Stacked on

[#13 (Adaptive BOS+EOS trim)](https://github.com/Jud/kokoro-coreml/pull/13). When that merges, GitHub auto-retargets this PR to `main`.

## Why this matters now (and why it doesn't)

**Why it matters:** Future-proofs the export pipeline. Any callsite that pads `input_ids` (e.g., for CoreML shape-cache, fixed-buffer interop, batch padding) used to silently produce wrong durations on padded positions. Now durations are stable across pad lengths, matching reference PyTorch math.

**Why it doesn't (yet):** Swift creates `MLMultiArray(shape: [1, n])` with `n = tokenIds.count` — production runtime never pads, so this fix is invisible to current users. Confirmed empirically: at N=7 (no padding) the OLD broken model and the NEW length-aware model produce identical `pred_dur`. Audio is essentially unchanged at production runtime.

This is real correctness work that we'd hit if we ever added padding for any reason (and we considered doing so to debug short utterances — see consult below). Shipping now while the diagnostic context is fresh.

## What changed

### `scripts/export_coreml.py`

- New `CoreMLPackedBidirLSTM` (drop-in replacement for `nn.LSTM(bidirectional=True)`):
  - Splits into separate forward + reverse unidirectional LSTMs.
  - Reverses only the valid prefix using a permutation-matrix matmul (`positions == rev_idx.unsqueeze(-1)` → matmul). Math is equivalent to a properly-packed bidir LSTM under right-padding.
  - We initially used `torch.gather`, but `coremltools.gather_along_axis` on dynamic shapes loses output shape info (becomes `tensor<fp32, [?, ?, ?]>`), which prevented the downstream LSTM from compiling (model-load error -14). Permutation matmul preserves shape and converts cleanly.
- New `CoreMLTextEncoder` — wraps `kokoro.modules.TextEncoder`, routes its LSTM through the wrapper.
- New `CoreMLDurationEncoder` — wraps `kokoro.modules.DurationEncoder`, routes each LSTM in its `lstms` ModuleList through the wrapper.
- `KokoroModelA.__init__` now holds `predictor` directly (preserves `predictor.shared`/`F0`/`N`/`F0_proj`/`N_proj` registration, used by `F0Ntrain`) plus the new wrappers for `text_encoder`, `predictor.text_encoder`, and `predictor.lstm`. The wrappers double-register weights in the traced state_dict but never trace those copies — see init comment.

### `scripts/debug_pred_dur_diff.py` (new)

Diagnostic harness that runs patched PyTorch (with the new wrappers) and the deployed CoreML over multiple pad lengths and prints per-token `pred_dur_clamped`. Used to verify the fix end-to-end.

## Validation

```
$ .venv/bin/python scripts/debug_pred_dur_diff.py --coreml \
    --frontend-path ./models_export/kokoro_frontend.mlpackage --texts "4." "Switch"

'4.' real_n=7 ids=[0, 48, 156, 76, 123, 4, 0]
  N=  7  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N=  8  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N= 16  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N= 24  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N= 32  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N= 64  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
  N=100  pt=[13, 2, 5, 5, 9, 7, 3] sum=44 | cm=[13, 2, 5, 5, 9, 7, 3] sum=44
```

For comparison, the OLD CoreML model (without this fix) collapses to `cm=[13, 2, 4, 3, 1, 1, 1] sum=25` at N=16+. Cliff is gone.

PyTorch reference (with patched `pack_padded_sequence` no-op + new wrappers) shows the same `[13, 2, 5, 5, 9, 7, 3]` durations for all N from 7 to 100. Cross-confirms the fix is correct in PyTorch and faithfully converts to CoreML.

## Test plan

- [x] `swift test` passes (no Swift code changed)
- [x] Re-export produces a model that loads at runtime (verified — model-load error -14 was the symptom we were chasing; gone)
- [x] `pred_dur` matches PyTorch across pad lengths (harness output above)
- [x] Listen test on `bf_lily "4."`, `bf_lily "Beauty."`, `af_heart "Switch" @ 0.85`, `af_heart "Switch off the lights."` — sounds equivalent to old model at production N=7 (expected; production runtime never pads)