### PR TITLE
Streaming + autoreleasepool drain + memcheck harness

### DIFF
--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -83,16 +83,17 @@ final class AudioEngine {
                 }
             }
         } catch {
-            self.error = "Synthesis failed: \(error.localizedDescription)"
-            self.isSynthesizing = false
-            if self.playerNode === player { teardown() }
+            if self.playerNode === player {
+                self.error = "Synthesis failed: \(error.localizedDescription)"
+                self.isSynthesizing = false
+                teardown()
+            }
             return
         }
 
-        self.isSynthesizing = false
-
         if Task.isCancelled || self.playerNode !== player { return }
 
+        self.isSynthesizing = false
         scheduleEndSentinel(on: player)
     }
 

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -17,6 +17,12 @@ final class AudioEngine {
     private var playerNode: AVAudioPlayerNode?
     private var streamTask: Task<Void, Never>?
     private var generation: UInt64 = 0
+    private var queuedFrames: AVAudioFramePosition = 0
+    private var drainContinuation: CheckedContinuation<Void, Never>?
+    private static let maxQueuedSeconds: Double = 2.0
+    private var maxQueuedFrames: AVAudioFramePosition {
+        AVAudioFramePosition(Self.maxQueuedSeconds * Double(KokoroEngine.sampleRate))
+    }
     private var _analyzer: SpectrumAnalyzer?
     private var spectrumAnalyzer: SpectrumAnalyzer {
         if let a = _analyzer { return a }
@@ -104,7 +110,7 @@ final class AudioEngine {
                     self.isSynthesizing = false
                     self.isPlaying = true
                 }
-                player.scheduleBuffer(buffer, completionHandler: nil)
+                await enqueue(buffer: buffer, on: player, generation: myGeneration)
             case .chunkFailed(let err):
                 self.error = "Chunk failed: \(err.localizedDescription)"
             }
@@ -145,6 +151,34 @@ final class AudioEngine {
         return player
     }
 
+    private func enqueue(
+        buffer: AVAudioPCMBuffer, on player: AVAudioPlayerNode, generation myGeneration: UInt64
+    ) async {
+        let frames = AVAudioFramePosition(buffer.frameLength)
+        while self.generation == myGeneration, !Task.isCancelled,
+            queuedFrames > maxQueuedFrames
+        {
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                drainContinuation = cont
+            }
+        }
+        guard self.generation == myGeneration, !Task.isCancelled else { return }
+        queuedFrames += frames
+        player.scheduleBuffer(
+            buffer, at: nil, options: [], completionCallbackType: .dataPlayedBack
+        ) { [weak self] _ in
+            Task { @MainActor in
+                guard let self else { return }
+                self.queuedFrames -= frames
+                if self.queuedFrames <= self.maxQueuedFrames {
+                    let cont = self.drainContinuation
+                    self.drainContinuation = nil
+                    cont?.resume()
+                }
+            }
+        }
+    }
+
     private func scheduleEndSentinel(on player: AVAudioPlayerNode, generation myGeneration: UInt64) {
         guard
             let sentinel = AVAudioPCMBuffer(
@@ -166,6 +200,10 @@ final class AudioEngine {
     }
 
     private func teardown() {
+        let pending = drainContinuation
+        drainContinuation = nil
+        pending?.resume()
+        queuedFrames = 0
         playerNode?.removeTap(onBus: 0)
         playerNode?.stop()
         avEngine?.stop()

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -4,7 +4,7 @@ import Observation
 
 @Observable
 @MainActor
-final class AudioEngine: NSObject, AVAudioPlayerDelegate {
+final class AudioEngine {
     var isPlaying = false
     var isSynthesizing = false
     var availableVoices: [String] = []
@@ -13,8 +13,9 @@ final class AudioEngine: NSObject, AVAudioPlayerDelegate {
     var levelMonitor: AudioLevelMonitor?
 
     private var engine: KokoroEngine?
-    private var player: AVAudioPlayer?
-    private var animationTask: Task<Void, Never>?
+    private var avEngine: AVAudioEngine?
+    private var playerNode: AVAudioPlayerNode?
+    private var streamTask: Task<Void, Never>?
     private var _analyzer: SpectrumAnalyzer?
     private var spectrumAnalyzer: SpectrumAnalyzer {
         if let a = _analyzer { return a }
@@ -41,128 +42,116 @@ final class AudioEngine: NSObject, AVAudioPlayerDelegate {
         isSynthesizing = true
         error = nil
 
-        let thread = Thread { [weak self] in
-            do {
-                let result = try engine.synthesize(text: text, voice: voice, speed: speed)
-                let wavData = Self.wavData(from: result.samples, sampleRate: KokoroEngine.sampleRate)
-
-                Task { @MainActor in
-                    guard let self, self.isSynthesizing else { return }
-                    self.isSynthesizing = false
-                    self.isPlaying = true
-                    self.playWAV(wavData, samples: result.samples)
-                }
-            } catch {
-                Task { @MainActor in
-                    self?.error = "Synthesis failed: \(error.localizedDescription)"
-                    self?.isSynthesizing = false
-                    self?.isPlaying = false
-                }
-            }
+        streamTask = Task { [weak self] in
+            await self?.run(engine: engine, text: text, voice: voice, speed: speed)
         }
-        thread.stackSize = 8 * 1024 * 1024
-        thread.start()
     }
 
     func stop() {
-        player?.stop()
+        streamTask?.cancel()
+        streamTask = nil
         teardown()
         isSynthesizing = false
     }
 
-    // MARK: - AVAudioPlayerDelegate
-
-    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        Task { @MainActor in self.teardown() }
-    }
-
     // MARK: - Private
 
+    private func run(engine: KokoroEngine, text: String, voice: String, speed: Float) async {
+        let player: AVAudioPlayerNode
+        do {
+            player = try startPlayback()
+        } catch {
+            self.error = "Playback setup failed: \(error.localizedDescription)"
+            self.isSynthesizing = false
+            return
+        }
+
+        do {
+            let stream = try engine.speak(text, voice: voice, speed: speed)
+            var firstBuffer = true
+            for await event in stream {
+                if Task.isCancelled { break }
+                switch event {
+                case .audio(let buffer):
+                    if firstBuffer {
+                        firstBuffer = false
+                        self.isPlaying = true
+                    }
+                    player.scheduleBuffer(buffer, completionHandler: nil)
+                case .chunkFailed(let err):
+                    self.error = "Chunk failed: \(err.localizedDescription)"
+                }
+            }
+        } catch {
+            self.error = "Synthesis failed: \(error.localizedDescription)"
+            teardown()
+            return
+        }
+
+        self.isSynthesizing = false
+
+        if Task.isCancelled {
+            teardown()
+            return
+        }
+
+        scheduleEndSentinel(on: player)
+    }
+
+    private func startPlayback() throws -> AVAudioPlayerNode {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .default)
+        try session.setActive(true)
+
+        let avEngine = AVAudioEngine()
+        let player = AVAudioPlayerNode()
+        avEngine.attach(player)
+        avEngine.connect(
+            player, to: avEngine.mainMixerNode, format: KokoroEngine.audioFormat)
+
+        let analyzer = self.spectrumAnalyzer
+        let monitor = self.levelMonitor
+        let tapFormat = avEngine.mainMixerNode.outputFormat(forBus: 0)
+        avEngine.mainMixerNode.installTap(
+            onBus: 0, bufferSize: 1024, format: tapFormat
+        ) { buffer, _ in
+            let bands = analyzer.analyze(buffer)
+            monitor?.pushBands(bands)
+        }
+
+        avEngine.prepare()
+        try avEngine.start()
+        player.play()
+
+        self.avEngine = avEngine
+        self.playerNode = player
+        return player
+    }
+
+    private func scheduleEndSentinel(on player: AVAudioPlayerNode) {
+        guard
+            let sentinel = AVAudioPCMBuffer(
+                pcmFormat: KokoroEngine.audioFormat, frameCapacity: 1)
+        else {
+            teardown()
+            return
+        }
+        sentinel.frameLength = 1
+        sentinel.floatChannelData?[0].pointee = 0
+        player.scheduleBuffer(
+            sentinel, at: nil, options: [], completionCallbackType: .dataPlayedBack
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.teardown() }
+        }
+    }
+
     private func teardown() {
-        animationTask?.cancel()
-        animationTask = nil
-        player = nil
+        playerNode?.stop()
+        avEngine?.mainMixerNode.removeTap(onBus: 0)
+        avEngine?.stop()
+        avEngine = nil
+        playerNode = nil
         isPlaying = false
         levelMonitor?.reset()
-    }
-
-    private func playWAV(_ data: Data, samples: [Float]) {
-        do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playback, mode: .default)
-            try session.setActive(true)
-
-            let audioPlayer = try AVAudioPlayer(data: data)
-            audioPlayer.delegate = self
-            audioPlayer.prepareToPlay()
-            audioPlayer.play()
-            self.player = audioPlayer
-
-            animateWaveform(samples: samples, duration: audioPlayer.duration)
-        } catch {
-            self.error = "Playback failed: \(error.localizedDescription)"
-            isPlaying = false
-        }
-    }
-
-    private func animateWaveform(samples: [Float], duration: Double) {
-        let analyzer = spectrumAnalyzer
-
-        animationTask?.cancel()
-        animationTask = Task { @MainActor [weak self] in
-            let sampleRate = Double(KokoroEngine.sampleRate)
-            let startTime = CFAbsoluteTimeGetCurrent()
-
-            while let self, self.isPlaying, !Task.isCancelled {
-                let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-                if elapsed >= duration + 0.2 { break }
-
-                let sampleIndex = Int(elapsed * sampleRate)
-                if sampleIndex < samples.count {
-                    let bands = analyzer.analyze(samples: samples, offset: sampleIndex)
-                    self.levelMonitor?.pushBands(bands)
-                }
-
-                try? await Task.sleep(for: .milliseconds(33))
-            }
-        }
-    }
-
-    /// Encode Float samples as a 16-bit PCM WAV in memory.
-    private static func wavData(from samples: [Float], sampleRate: Int) -> Data {
-        let numSamples = samples.count
-        let dataSize = numSamples * 2
-        let fileSize = 44 + dataSize
-
-        var data = Data(capacity: fileSize)
-
-        func appendLE<T: FixedWidthInteger>(_ value: T) {
-            var v = value.littleEndian
-            withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
-        }
-
-        data.append(contentsOf: [0x52, 0x49, 0x46, 0x46])  // "RIFF"
-        appendLE(UInt32(fileSize - 8))
-        data.append(contentsOf: [0x57, 0x41, 0x56, 0x45])  // "WAVE"
-        data.append(contentsOf: [0x66, 0x6D, 0x74, 0x20])  // "fmt "
-        appendLE(UInt32(16))
-        appendLE(UInt16(1))  // PCM
-        appendLE(UInt16(1))  // mono
-        appendLE(UInt32(sampleRate))
-        appendLE(UInt32(sampleRate * 2))
-        appendLE(UInt16(2))  // block align
-        appendLE(UInt16(16))  // bits per sample
-        data.append(contentsOf: [0x64, 0x61, 0x74, 0x61])  // "data"
-        appendLE(UInt32(dataSize))
-
-        // Bulk convert float samples to Int16
-        var int16Samples = [Int16](repeating: 0, count: numSamples)
-        for i in 0..<numSamples {
-            let clamped = max(-1.0, min(1.0, samples[i]))
-            int16Samples[i] = Int16(clamped * 32767)
-        }
-        int16Samples.withUnsafeBytes { data.append(contentsOf: $0) }
-
-        return data
     }
 }

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -70,7 +70,7 @@ final class AudioEngine {
             let stream = try engine.speak(text, voice: voice, speed: speed)
             var firstBuffer = true
             for await event in stream {
-                if Task.isCancelled { break }
+                if Task.isCancelled || self.playerNode !== player { break }
                 switch event {
                 case .audio(let buffer):
                     if firstBuffer {
@@ -84,16 +84,14 @@ final class AudioEngine {
             }
         } catch {
             self.error = "Synthesis failed: \(error.localizedDescription)"
-            teardown()
+            self.isSynthesizing = false
+            if self.playerNode === player { teardown() }
             return
         }
 
         self.isSynthesizing = false
 
-        if Task.isCancelled {
-            teardown()
-            return
-        }
+        if Task.isCancelled || self.playerNode !== player { return }
 
         scheduleEndSentinel(on: player)
     }
@@ -111,9 +109,8 @@ final class AudioEngine {
 
         let analyzer = self.spectrumAnalyzer
         let monitor = self.levelMonitor
-        let tapFormat = avEngine.mainMixerNode.outputFormat(forBus: 0)
-        avEngine.mainMixerNode.installTap(
-            onBus: 0, bufferSize: 1024, format: tapFormat
+        player.installTap(
+            onBus: 0, bufferSize: 1024, format: KokoroEngine.audioFormat
         ) { buffer, _ in
             let bands = analyzer.analyze(buffer)
             monitor?.pushBands(bands)
@@ -133,7 +130,7 @@ final class AudioEngine {
             let sentinel = AVAudioPCMBuffer(
                 pcmFormat: KokoroEngine.audioFormat, frameCapacity: 1)
         else {
-            teardown()
+            if self.playerNode === player { teardown() }
             return
         }
         sentinel.frameLength = 1
@@ -141,13 +138,16 @@ final class AudioEngine {
         player.scheduleBuffer(
             sentinel, at: nil, options: [], completionCallbackType: .dataPlayedBack
         ) { [weak self] _ in
-            Task { @MainActor [weak self] in self?.teardown() }
+            Task { @MainActor in
+                guard let self, self.playerNode === player else { return }
+                self.teardown()
+            }
         }
     }
 
     private func teardown() {
+        playerNode?.removeTap(onBus: 0)
         playerNode?.stop()
-        avEngine?.mainMixerNode.removeTap(onBus: 0)
         avEngine?.stop()
         avEngine = nil
         playerNode = nil

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -168,7 +168,7 @@ final class AudioEngine {
             buffer, at: nil, options: [], completionCallbackType: .dataPlayedBack
         ) { [weak self] _ in
             Task { @MainActor in
-                guard let self else { return }
+                guard let self, self.generation == myGeneration else { return }
                 self.queuedFrames -= frames
                 if self.queuedFrames <= self.maxQueuedFrames {
                     let cont = self.drainContinuation

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -80,22 +80,11 @@ final class AudioEngine {
             return
         }
 
+        let stream: AsyncStream<SpeakEvent>
         do {
-            let stream = try engine.speak(text, voice: voice, speed: speed)
-            var firstBuffer = true
-            for await event in stream {
-                if !current() { break }
-                switch event {
-                case .audio(let buffer):
-                    if firstBuffer {
-                        firstBuffer = false
-                        self.isPlaying = true
-                    }
-                    player.scheduleBuffer(buffer, completionHandler: nil)
-                case .chunkFailed(let err):
-                    self.error = "Chunk failed: \(err.localizedDescription)"
-                }
-            }
+            stream = try await Task.detached(priority: .userInitiated) {
+                try engine.speak(text, voice: voice, speed: speed)
+            }.value
         } catch {
             if current() {
                 self.error = "Synthesis failed: \(error.localizedDescription)"
@@ -103,6 +92,22 @@ final class AudioEngine {
                 teardown()
             }
             return
+        }
+
+        var firstBuffer = true
+        for await event in stream {
+            if !current() { break }
+            switch event {
+            case .audio(let buffer):
+                if firstBuffer {
+                    firstBuffer = false
+                    self.isSynthesizing = false
+                    self.isPlaying = true
+                }
+                player.scheduleBuffer(buffer, completionHandler: nil)
+            case .chunkFailed(let err):
+                self.error = "Chunk failed: \(err.localizedDescription)"
+            }
         }
 
         if !current() { return }

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -17,12 +17,6 @@ final class AudioEngine {
     private var playerNode: AVAudioPlayerNode?
     private var streamTask: Task<Void, Never>?
     private var generation: UInt64 = 0
-    private var queuedFrames: AVAudioFramePosition = 0
-    private var drainContinuation: CheckedContinuation<Void, Never>?
-    private static let maxQueuedSeconds: Double = 2.0
-    private var maxQueuedFrames: AVAudioFramePosition {
-        AVAudioFramePosition(Self.maxQueuedSeconds * Double(KokoroEngine.sampleRate))
-    }
     private var _analyzer: SpectrumAnalyzer?
     private var spectrumAnalyzer: SpectrumAnalyzer {
         if let a = _analyzer { return a }
@@ -110,7 +104,7 @@ final class AudioEngine {
                     self.isSynthesizing = false
                     self.isPlaying = true
                 }
-                await enqueue(buffer: buffer, on: player, generation: myGeneration)
+                player.scheduleBuffer(buffer, completionHandler: nil)
             case .chunkFailed(let err):
                 self.error = "Chunk failed: \(err.localizedDescription)"
             }
@@ -151,34 +145,6 @@ final class AudioEngine {
         return player
     }
 
-    private func enqueue(
-        buffer: AVAudioPCMBuffer, on player: AVAudioPlayerNode, generation myGeneration: UInt64
-    ) async {
-        let frames = AVAudioFramePosition(buffer.frameLength)
-        while self.generation == myGeneration, !Task.isCancelled,
-            queuedFrames > maxQueuedFrames
-        {
-            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                drainContinuation = cont
-            }
-        }
-        guard self.generation == myGeneration, !Task.isCancelled else { return }
-        queuedFrames += frames
-        player.scheduleBuffer(
-            buffer, at: nil, options: [], completionCallbackType: .dataPlayedBack
-        ) { [weak self] _ in
-            Task { @MainActor in
-                guard let self, self.generation == myGeneration else { return }
-                self.queuedFrames -= frames
-                if self.queuedFrames <= self.maxQueuedFrames {
-                    let cont = self.drainContinuation
-                    self.drainContinuation = nil
-                    cont?.resume()
-                }
-            }
-        }
-    }
-
     private func scheduleEndSentinel(on player: AVAudioPlayerNode, generation myGeneration: UInt64) {
         guard
             let sentinel = AVAudioPCMBuffer(
@@ -200,10 +166,6 @@ final class AudioEngine {
     }
 
     private func teardown() {
-        let pending = drainContinuation
-        drainContinuation = nil
-        pending?.resume()
-        queuedFrames = 0
         playerNode?.removeTap(onBus: 0)
         playerNode?.stop()
         avEngine?.stop()

--- a/Examples/KokoroApp/KokoroApp/AudioEngine.swift
+++ b/Examples/KokoroApp/KokoroApp/AudioEngine.swift
@@ -16,6 +16,7 @@ final class AudioEngine {
     private var avEngine: AVAudioEngine?
     private var playerNode: AVAudioPlayerNode?
     private var streamTask: Task<Void, Never>?
+    private var generation: UInt64 = 0
     private var _analyzer: SpectrumAnalyzer?
     private var spectrumAnalyzer: SpectrumAnalyzer {
         if let a = _analyzer { return a }
@@ -39,15 +40,19 @@ final class AudioEngine {
         guard let engine, !text.isEmpty else { return }
 
         stop()
+        let myGeneration = generation
         isSynthesizing = true
         error = nil
 
         streamTask = Task { [weak self] in
-            await self?.run(engine: engine, text: text, voice: voice, speed: speed)
+            await self?.run(
+                engine: engine, text: text, voice: voice,
+                speed: speed, generation: myGeneration)
         }
     }
 
     func stop() {
+        generation &+= 1
         streamTask?.cancel()
         streamTask = nil
         teardown()
@@ -56,13 +61,22 @@ final class AudioEngine {
 
     // MARK: - Private
 
-    private func run(engine: KokoroEngine, text: String, voice: String, speed: Float) async {
+    private func run(
+        engine: KokoroEngine, text: String, voice: String,
+        speed: Float, generation myGeneration: UInt64
+    ) async {
+        func current() -> Bool {
+            !Task.isCancelled && self.generation == myGeneration
+        }
+
         let player: AVAudioPlayerNode
         do {
             player = try startPlayback()
         } catch {
-            self.error = "Playback setup failed: \(error.localizedDescription)"
-            self.isSynthesizing = false
+            if current() {
+                self.error = "Playback setup failed: \(error.localizedDescription)"
+                self.isSynthesizing = false
+            }
             return
         }
 
@@ -70,7 +84,7 @@ final class AudioEngine {
             let stream = try engine.speak(text, voice: voice, speed: speed)
             var firstBuffer = true
             for await event in stream {
-                if Task.isCancelled || self.playerNode !== player { break }
+                if !current() { break }
                 switch event {
                 case .audio(let buffer):
                     if firstBuffer {
@@ -83,7 +97,7 @@ final class AudioEngine {
                 }
             }
         } catch {
-            if self.playerNode === player {
+            if current() {
                 self.error = "Synthesis failed: \(error.localizedDescription)"
                 self.isSynthesizing = false
                 teardown()
@@ -91,10 +105,10 @@ final class AudioEngine {
             return
         }
 
-        if Task.isCancelled || self.playerNode !== player { return }
+        if !current() { return }
 
         self.isSynthesizing = false
-        scheduleEndSentinel(on: player)
+        scheduleEndSentinel(on: player, generation: myGeneration)
     }
 
     private func startPlayback() throws -> AVAudioPlayerNode {
@@ -126,12 +140,12 @@ final class AudioEngine {
         return player
     }
 
-    private func scheduleEndSentinel(on player: AVAudioPlayerNode) {
+    private func scheduleEndSentinel(on player: AVAudioPlayerNode, generation myGeneration: UInt64) {
         guard
             let sentinel = AVAudioPCMBuffer(
                 pcmFormat: KokoroEngine.audioFormat, frameCapacity: 1)
         else {
-            if self.playerNode === player { teardown() }
+            if self.generation == myGeneration { teardown() }
             return
         }
         sentinel.frameLength = 1
@@ -140,7 +154,7 @@ final class AudioEngine {
             sentinel, at: nil, options: [], completionCallbackType: .dataPlayedBack
         ) { [weak self] _ in
             Task { @MainActor in
-                guard let self, self.playerNode === player else { return }
+                guard let self, self.generation == myGeneration else { return }
                 self.teardown()
             }
         }

--- a/Examples/KokoroApp/KokoroApp/KokoroAppApp.swift
+++ b/Examples/KokoroApp/KokoroApp/KokoroAppApp.swift
@@ -4,8 +4,12 @@ import SwiftUI
 struct KokoroAppApp: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .preferredColorScheme(.dark)
+            if MemoryTestRunner.isRequested {
+                MemoryTestView()
+            } else {
+                ContentView()
+                    .preferredColorScheme(.dark)
+            }
         }
     }
 }

--- a/Examples/KokoroApp/KokoroApp/MemoryMeter.swift
+++ b/Examples/KokoroApp/KokoroApp/MemoryMeter.swift
@@ -1,0 +1,18 @@
+import Darwin
+
+/// Reads `phys_footprint` via `task_info`, the same value iOS jetsam uses to
+/// decide whether to kill the app. Returns megabytes.
+enum MemoryMeter {
+    static func physFootprintMB() -> Double {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) { infoPtr in
+            infoPtr.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { intPtr in
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), intPtr, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return -1 }
+        return Double(info.phys_footprint) / 1024.0 / 1024.0
+    }
+}

--- a/Examples/KokoroApp/KokoroApp/MemoryTestRunner.swift
+++ b/Examples/KokoroApp/KokoroApp/MemoryTestRunner.swift
@@ -82,7 +82,7 @@ enum MemoryTestRunner {
         recorder.event("case_start", detail: "\(voice)/\(label)")
 
         let stream = try await Task.detached(priority: .userInitiated) {
-            try engine.speak(text, voice: voice, speed: 1.0)
+            try engine.speak(text, voice: voice, speed: 1.0, paceToRealtime: false)
         }.value
 
         var bufferCount = 0

--- a/Examples/KokoroApp/KokoroApp/MemoryTestRunner.swift
+++ b/Examples/KokoroApp/KokoroApp/MemoryTestRunner.swift
@@ -1,0 +1,219 @@
+import Foundation
+import KokoroCoreML
+import SwiftUI
+
+/// Deterministic synthesis suite that records phys_footprint at lifecycle
+/// events and at 10Hz throughout, then prints a JSON summary and exits.
+///
+/// Triggered by passing `--memory-test` on launch. Output is fenced with
+/// `MEMORY_TEST_RESULT_START` / `MEMORY_TEST_RESULT_END` markers so a CI
+/// script can extract the JSON from a noisy log.
+enum MemoryTestRunner {
+    static var isRequested: Bool {
+        CommandLine.arguments.contains("--memory-test")
+    }
+
+    @MainActor
+    static func runAndExit() async -> Never {
+        let recorder = MemoryRecorder()
+        recorder.event("startup")
+
+        do {
+            let engine = try loadEngine(recorder: recorder)
+            try await runSuite(engine: engine, recorder: recorder)
+        } catch {
+            recorder.event("error", detail: "\(error)")
+        }
+
+        recorder.event("teardown")
+        let result = recorder.finish()
+        emit(result)
+        fflush(stdout)
+        exit(EXIT_SUCCESS)
+    }
+
+    @MainActor
+    private static func loadEngine(recorder: MemoryRecorder) throws -> KokoroEngine {
+        recorder.event("pre_engine_load")
+        let bundledPath = Bundle.main.resourceURL?.appendingPathComponent("Models")
+        let modelDir: URL
+        if let bundled = bundledPath, KokoroEngine.isDownloaded(at: bundled) {
+            modelDir = bundled
+        } else {
+            modelDir = KokoroEngine.defaultModelDirectory
+        }
+        let engine = try KokoroEngine(modelDirectory: modelDir)
+        recorder.event("post_engine_load", detail: "voices=\(engine.availableVoices.count)")
+        return engine
+    }
+
+    @MainActor
+    private static func runSuite(engine: KokoroEngine, recorder: MemoryRecorder) async throws {
+        let voices = pickRepresentativeVoices(from: engine.availableVoices)
+        let utterances: [(label: String, text: String)] = [
+            ("short", "Hello, how are you today?"),
+            (
+                "medium",
+                String(repeating: "This is a sentence used to exercise medium-length synthesis. ", count: 4)
+            ),
+            (
+                "long",
+                String(
+                    repeating:
+                        "Long-form synthesis exercises the streaming path across many chunks, including inter-chunk silence and the gain locked in from the first chunk. ",
+                    count: 6)
+            ),
+        ]
+
+        for voice in voices {
+            for u in utterances {
+                try await runOneCase(
+                    engine: engine, voice: voice, label: u.label,
+                    text: u.text, recorder: recorder)
+            }
+        }
+    }
+
+    @MainActor
+    private static func runOneCase(
+        engine: KokoroEngine, voice: String, label: String,
+        text: String, recorder: MemoryRecorder
+    ) async throws {
+        recorder.event("case_start", detail: "\(voice)/\(label)")
+
+        let stream = try await Task.detached(priority: .userInitiated) {
+            try engine.speak(text, voice: voice, speed: 1.0)
+        }.value
+
+        var bufferCount = 0
+        for await event in stream {
+            switch event {
+            case .audio(let buffer):
+                bufferCount += 1
+                if bufferCount == 1 {
+                    recorder.event("first_buffer", detail: "\(voice)/\(label)")
+                }
+                _ = buffer.frameLength
+            case .chunkFailed(let err):
+                recorder.event("chunk_failed", detail: err.localizedDescription)
+            }
+        }
+
+        recorder.event("case_end", detail: "\(voice)/\(label) buffers=\(bufferCount)")
+    }
+
+    private static func pickRepresentativeVoices(from voices: [String]) -> [String] {
+        let candidates = ["af_heart", "am_michael", "bf_emma"]
+        let picked = candidates.filter { voices.contains($0) }
+        if !picked.isEmpty { return picked }
+        return Array(voices.prefix(3))
+    }
+
+    private static func emit(_ result: MemoryTestResult) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard
+            let data = try? encoder.encode(result),
+            let json = String(data: data, encoding: .utf8)
+        else { return }
+        print("MEMORY_TEST_RESULT_START")
+        print(json)
+        print("MEMORY_TEST_RESULT_END")
+    }
+}
+
+// MARK: - Recorder
+
+@MainActor
+final class MemoryRecorder {
+    private var events: [MemoryEvent] = []
+    private var samples: [MemorySample] = []
+    private let baseline: Double
+    private let startTime: CFAbsoluteTime
+    private var pollTimer: Timer?
+
+    init() {
+        startTime = CFAbsoluteTimeGetCurrent()
+        baseline = MemoryMeter.physFootprintMB()
+        startPolling()
+    }
+
+    func event(_ name: String, detail: String? = nil) {
+        let t = CFAbsoluteTimeGetCurrent() - startTime
+        events.append(
+            MemoryEvent(
+                name: name, timeSeconds: t,
+                mb: MemoryMeter.physFootprintMB(), detail: detail))
+    }
+
+    func finish() -> MemoryTestResult {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        let peak = max(
+            samples.map(\.mb).max() ?? 0,
+            events.map(\.mb).max() ?? 0)
+        return MemoryTestResult(
+            durationSeconds: CFAbsoluteTimeGetCurrent() - startTime,
+            baselineMB: baseline,
+            peakMB: peak,
+            peakDeltaMB: peak - baseline,
+            events: events,
+            samples: samples)
+    }
+
+    private func startPolling() {
+        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) {
+            [weak self] _ in
+            guard let self else { return }
+            let t = CFAbsoluteTimeGetCurrent() - self.startTime
+            self.samples.append(
+                MemorySample(
+                    timeSeconds: t, mb: MemoryMeter.physFootprintMB()))
+        }
+    }
+}
+
+// MARK: - Schema
+
+struct MemoryTestResult: Codable {
+    let durationSeconds: Double
+    let baselineMB: Double
+    let peakMB: Double
+    let peakDeltaMB: Double
+    let events: [MemoryEvent]
+    let samples: [MemorySample]
+}
+
+struct MemoryEvent: Codable {
+    let name: String
+    let timeSeconds: Double
+    let mb: Double
+    let detail: String?
+}
+
+struct MemorySample: Codable {
+    let timeSeconds: Double
+    let mb: Double
+}
+
+// MARK: - SwiftUI host
+
+/// Minimal view that shows progress while the test suite runs.
+struct MemoryTestView: View {
+    @State private var status = "Running memory test..."
+
+    var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+            Text(status)
+                .font(.system(.body, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .preferredColorScheme(.dark)
+        .task {
+            await MemoryTestRunner.runAndExit()
+        }
+    }
+}

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -411,9 +411,9 @@ public final class KokoroEngine: @unchecked Sendable {
     /// so a near-silent first chunk doesn't blow up later content or noise.
     private static let streamGainCeiling: Float = 2.0
 
-    /// Numerical floor to keep gain finite. Below 1.0 so we can attenuate
-    /// when the first chunk is naturally louder than the target level —
-    /// preserves headroom for later chunks at risk of clipping.
+    /// Numerical floor on the computed gain. Set well under 1.0 so a chunk
+    /// louder than the target level can be attenuated, preserving headroom
+    /// for later chunks at risk of clipping.
     private static let streamGainFloor: Float = 0.01
 
     /// Compute fixed gain from a chunk's peak so all chunks in the stream use
@@ -427,11 +427,9 @@ public final class KokoroEngine: @unchecked Sendable {
         return min(streamGainCeiling, max(streamGainFloor, raw))
     }
 
-    /// Apply gain in-place. If a later chunk exceeds the first chunk's amplitude
-    /// after gain (rare for TTS but possible), rescale that chunk to ±0.99 peak
-    /// instead of hard-clipping every overshooting sample at ±0.95 — keeps the
-    /// chunk-to-chunk loudness mostly constant without introducing the audible
-    /// distortion the previous hard clip produced.
+    /// Apply gain in-place. If the chunk peaks above 1.0 after gain, rescale
+    /// it to ±0.99 so the rare overshooting chunk lands inside the playback
+    /// range without per-sample clipping distortion.
     private static func applyStreamGain(_ samples: inout [Float], gain: Float) {
         var g = gain
         vDSP_vsmul(samples, 1, &g, &samples, 1, vDSP_Length(samples.count))

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -1129,7 +1129,17 @@ public final class KokoroEngine: @unchecked Sendable {
                     if paceToRealtime {
                         let lead = audioProduced - (CFAbsoluteTimeGetCurrent() - streamStart)
                         if lead > Self.producerLeadSeconds {
-                            Thread.sleep(forTimeInterval: lead - Self.producerLeadSeconds)
+                            // Sleep in short increments so onTermination's
+                            // Thread.cancel() tears the worker down promptly
+                            // instead of waiting out the full pacing delay.
+                            let target =
+                                CFAbsoluteTimeGetCurrent()
+                                + (lead - Self.producerLeadSeconds)
+                            while !Thread.current.isCancelled {
+                                let remaining = target - CFAbsoluteTimeGetCurrent()
+                                if remaining <= 0 { break }
+                                Thread.sleep(forTimeInterval: min(0.05, remaining))
+                            }
                             if Thread.current.isCancelled { break }
                         }
                     }

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -401,11 +401,23 @@ public final class KokoroEngine: @unchecked Sendable {
 
         var peak: Float = 0
         vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
-        if peak > 0.001 {
-            var scale = Float(0.95) / peak
+        if peak > silencePeakThreshold {
+            var scale = targetPeakAmplitude / peak
             vDSP_vsmul(samples, 1, &scale, &samples, 1, vDSP_Length(samples.count))
         }
     }
+
+    /// Target peak amplitude for normalized audio. Sits under 1.0 to leave
+    /// headroom against post-filter overshoot before the playback range.
+    private static let targetPeakAmplitude: Float = 0.95
+
+    /// Peak amplitude under which a chunk is treated as silent — skip gain
+    /// to avoid amplifying numerical noise.
+    private static let silencePeakThreshold: Float = 0.001
+
+    /// Landing peak when a chunk overshoots ±1.0 after gain. Just inside the
+    /// playback range so the rescaled chunk doesn't clip on quantization.
+    private static let overshootRescalePeak: Float = 0.99
 
     /// Gain ceiling for streaming normalization. Caps boost on quiet utterances
     /// so a near-silent first chunk doesn't blow up later content or noise.
@@ -422,21 +434,21 @@ public final class KokoroEngine: @unchecked Sendable {
     private static func computeStreamGain(from samples: [Float]) -> Float {
         var peak: Float = 0
         vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
-        guard peak > 0.001 else { return 1.0 }
-        let raw = Float(0.95) / peak
+        guard peak > silencePeakThreshold else { return 1.0 }
+        let raw = targetPeakAmplitude / peak
         return min(streamGainCeiling, max(streamGainFloor, raw))
     }
 
     /// Apply gain in-place. If the chunk peaks above 1.0 after gain, rescale
-    /// it to ±0.99 so the rare overshooting chunk lands inside the playback
-    /// range without per-sample clipping distortion.
+    /// it to ±overshootRescalePeak so the rare overshooting chunk lands inside
+    /// the playback range without per-sample clipping distortion.
     private static func applyStreamGain(_ samples: inout [Float], gain: Float) {
         var g = gain
         vDSP_vsmul(samples, 1, &g, &samples, 1, vDSP_Length(samples.count))
         var peak: Float = 0
         vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
         if peak > 1.0 {
-            var scale: Float = 0.99 / peak
+            var scale: Float = overshootRescalePeak / peak
             vDSP_vsmul(samples, 1, &scale, &samples, 1, vDSP_Length(samples.count))
         }
     }
@@ -449,19 +461,10 @@ public final class KokoroEngine: @unchecked Sendable {
 
     /// Fresh 100ms silence buffer for inter-chunk gaps. A new instance per
     /// call keeps `SpeakEvent.audio` buffers unaliased — concurrent or
-    /// retaining consumers never observe the same `AVAudioPCMBuffer`
-    /// scheduled on two player nodes at once.
+    /// retaining consumers never observe the same `AVAudioPCMBuffer` twice.
     private static func makeSilenceBuffer() -> AVAudioPCMBuffer? {
-        guard
-            let buffer = AVAudioPCMBuffer(
-                pcmFormat: audioFormat,
-                frameCapacity: AVAudioFrameCount(interChunkSilence))
-        else { return nil }
-        buffer.frameLength = AVAudioFrameCount(interChunkSilence)
-        if let channel = buffer.floatChannelData?[0] {
-            memset(channel, 0, interChunkSilence * MemoryLayout<Float>.stride)
-        }
-        return buffer
+        makePCMBuffer(
+            from: [Float](repeating: 0, count: interChunkSilence), format: audioFormat)
     }
 
     // MARK: - Voices
@@ -1059,10 +1062,16 @@ public final class KokoroEngine: @unchecked Sendable {
         standardFormatWithSampleRate: Double(sampleRate), channels: 1)!
 
     /// Stream synthesized audio as playback-ready buffers.
+    ///
+    /// `paceToRealtime`: when true (default), the producer thread sleeps after
+    /// each chunk to stay within `producerLeadSeconds` of a real-time
+    /// consumer — the right behavior for live playback. Set false for batch
+    /// consumers (file export, tests) that want full synthesis throughput.
     public func speak(
         _ text: String,
         voice: String,
-        speed: Float = 1.0
+        speed: Float = 1.0,
+        paceToRealtime: Bool = true
     ) throws -> AsyncStream<SpeakEvent> {
         guard availableVoices.contains(voice) else {
             throw KokoroError.voiceNotFound(voice)
@@ -1072,7 +1081,9 @@ public final class KokoroEngine: @unchecked Sendable {
         let (_, mergedIds) = prepareChunks(text: text)
         guard !mergedIds.isEmpty else { return AsyncStream { $0.finish() } }
 
-        return streamSpeakLoop(mergedIds: mergedIds, speed: clampedSpeed) { tokenCount in
+        return streamSpeakLoop(
+            mergedIds: mergedIds, speed: clampedSpeed, paceToRealtime: paceToRealtime
+        ) { tokenCount in
             try self.voiceStore.embedding(for: voice, tokenCount: tokenCount)
         }
     }
@@ -1081,13 +1092,16 @@ public final class KokoroEngine: @unchecked Sendable {
     public func speak(
         _ text: String,
         styleVector: [Float],
-        speed: Float = 1.0
+        speed: Float = 1.0,
+        paceToRealtime: Bool = true
     ) throws -> AsyncStream<SpeakEvent> {
         let clampedSpeed = Self.clampSpeed(speed)
         let (_, mergedIds) = prepareChunks(text: text)
         guard !mergedIds.isEmpty else { return AsyncStream { $0.finish() } }
 
-        return streamSpeakLoop(mergedIds: mergedIds, speed: clampedSpeed) { _ in
+        return streamSpeakLoop(
+            mergedIds: mergedIds, speed: clampedSpeed, paceToRealtime: paceToRealtime
+        ) { _ in
             styleVector
         }
     }
@@ -1098,6 +1112,7 @@ public final class KokoroEngine: @unchecked Sendable {
     private func streamSpeakLoop(
         mergedIds: [[Int]],
         speed: Float,
+        paceToRealtime: Bool,
         styleVectorFor: @escaping @Sendable (Int) throws -> [Float]
     ) -> AsyncStream<SpeakEvent> {
         return AsyncStream { continuation in
@@ -1105,18 +1120,14 @@ public final class KokoroEngine: @unchecked Sendable {
                 let format = Self.audioFormat
                 var streamGain: Float? = nil
                 var emittedFirst = false
-                let streamStart = Date()
+                let streamStart = CFAbsoluteTimeGetCurrent()
                 var audioProduced: TimeInterval = 0
 
                 for tokenIds in mergedIds {
                     if Thread.current.isCancelled { break }
 
-                    // Pace producer to within `producerLeadSeconds` of a real-time
-                    // consumer. Without this, fast synthesis on simulator/desktop
-                    // stuffs an unbounded number of AVAudioPCMBuffers into the
-                    // AsyncStream buffer and the consumer's player queue.
-                    if audioProduced > 0 {
-                        let lead = audioProduced - Date().timeIntervalSince(streamStart)
+                    if paceToRealtime {
+                        let lead = audioProduced - (CFAbsoluteTimeGetCurrent() - streamStart)
                         if lead > Self.producerLeadSeconds {
                             Thread.sleep(forTimeInterval: lead - Self.producerLeadSeconds)
                             if Thread.current.isCancelled { break }

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -407,11 +407,14 @@ public final class KokoroEngine: @unchecked Sendable {
         }
     }
 
-    /// Gain ceiling for streaming normalization. Caps boost on quiet utterances.
+    /// Gain ceiling for streaming normalization. Caps boost on quiet utterances
+    /// so a near-silent first chunk doesn't blow up later content or noise.
     private static let streamGainCeiling: Float = 2.0
 
-    /// Gain floor for streaming normalization. Prevents attenuation of loud chunks.
-    private static let streamGainFloor: Float = 1.0
+    /// Numerical floor to keep gain finite. Below 1.0 so we can attenuate
+    /// when the first chunk is naturally louder than the target level —
+    /// preserves headroom for later chunks at risk of clipping.
+    private static let streamGainFloor: Float = 0.01
 
     /// Compute fixed gain from a chunk's peak so all chunks in the stream use
     /// the same scale — avoids the loudness jumps you'd get from per-chunk
@@ -424,13 +427,20 @@ public final class KokoroEngine: @unchecked Sendable {
         return min(streamGainCeiling, max(streamGainFloor, raw))
     }
 
-    /// Apply gain in-place and hard-clip to ±0.95.
+    /// Apply gain in-place. If a later chunk exceeds the first chunk's amplitude
+    /// after gain (rare for TTS but possible), rescale that chunk to ±0.99 peak
+    /// instead of hard-clipping every overshooting sample at ±0.95 — keeps the
+    /// chunk-to-chunk loudness mostly constant without introducing the audible
+    /// distortion the previous hard clip produced.
     private static func applyStreamGain(_ samples: inout [Float], gain: Float) {
         var g = gain
         vDSP_vsmul(samples, 1, &g, &samples, 1, vDSP_Length(samples.count))
-        var lo: Float = -0.95
-        var hi: Float = 0.95
-        vDSP_vclip(samples, 1, &lo, &hi, &samples, 1, vDSP_Length(samples.count))
+        var peak: Float = 0
+        vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
+        if peak > 1.0 {
+            var scale: Float = 0.99 / peak
+            vDSP_vsmul(samples, 1, &scale, &samples, 1, vDSP_Length(samples.count))
+        }
     }
 
     /// Maximum seconds of audio the producer may sit ahead of a real-time

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -447,9 +447,11 @@ public final class KokoroEngine: @unchecked Sendable {
     /// runs faster than playback.
     private static let producerLeadSeconds: TimeInterval = 2.0
 
-    /// Shared 100ms silence buffer for inter-chunk gaps. Read-only after init,
-    /// so it's safe to enqueue the same instance on the player node every call.
-    private static let interChunkSilenceBuffer: AVAudioPCMBuffer? = {
+    /// Fresh 100ms silence buffer for inter-chunk gaps. A new instance per
+    /// call keeps `SpeakEvent.audio` buffers unaliased — concurrent or
+    /// retaining consumers never observe the same `AVAudioPCMBuffer`
+    /// scheduled on two player nodes at once.
+    private static func makeSilenceBuffer() -> AVAudioPCMBuffer? {
         guard
             let buffer = AVAudioPCMBuffer(
                 pcmFormat: audioFormat,
@@ -460,7 +462,7 @@ public final class KokoroEngine: @unchecked Sendable {
             memset(channel, 0, interChunkSilence * MemoryLayout<Float>.stride)
         }
         return buffer
-    }()
+    }
 
     // MARK: - Voices
 
@@ -1136,7 +1138,7 @@ public final class KokoroEngine: @unchecked Sendable {
                             streamGain = gain
                             Self.applyStreamGain(&samples, gain: gain)
 
-                            if emittedFirst, let silence = Self.interChunkSilenceBuffer {
+                            if emittedFirst, let silence = Self.makeSilenceBuffer() {
                                 continuation.yield(.audio(silence))
                                 audioProduced +=
                                     Double(silence.frameLength) / Double(Self.sampleRate)

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -351,8 +351,9 @@ public final class KokoroEngine: @unchecked Sendable {
 
     private static let hpAlpha: Float = 1.0 - (2.0 * .pi * 80.0 / Float(sampleRate))
 
-    /// Post-process audio in-place: high-pass filter, presence boost, peak normalize.
-    private static func postProcess(_ samples: inout [Float]) {
+    /// HP filter + presence-boost EQ. Precharges from the chunk head, so it's
+    /// safe to call per chunk without audible seams.
+    private static func applyFiltering(_ samples: inout [Float]) {
         guard samples.count > 1 else { return }
 
         let alpha = hpAlpha
@@ -387,6 +388,12 @@ public final class KokoroEngine: @unchecked Sendable {
             y2 = y1; y1 = y
             samples[i] = y
         }
+    }
+
+    /// Post-process audio in-place: high-pass filter, presence boost, peak normalize.
+    private static func postProcess(_ samples: inout [Float]) {
+        guard samples.count > 1 else { return }
+        applyFiltering(&samples)
 
         var peak: Float = 0
         vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
@@ -394,6 +401,46 @@ public final class KokoroEngine: @unchecked Sendable {
             var scale = Float(0.95) / peak
             vDSP_vsmul(samples, 1, &scale, &samples, 1, vDSP_Length(samples.count))
         }
+    }
+
+    /// Gain ceiling for streaming normalization. Caps boost on quiet utterances.
+    private static let streamGainCeiling: Float = 2.0
+
+    /// Gain floor for streaming normalization. Prevents attenuation of loud chunks.
+    private static let streamGainFloor: Float = 1.0
+
+    /// Compute fixed gain from a chunk's peak so all chunks in the stream use
+    /// the same scale — avoids the loudness jumps you'd get from per-chunk
+    /// peak normalization.
+    private static func computeStreamGain(from samples: [Float]) -> Float {
+        var peak: Float = 0
+        vDSP_maxmgv(samples, 1, &peak, vDSP_Length(samples.count))
+        guard peak > 0.001 else { return 1.0 }
+        let raw = Float(0.95) / peak
+        return min(streamGainCeiling, max(streamGainFloor, raw))
+    }
+
+    /// Apply gain in-place and hard-clip to ±0.95.
+    private static func applyStreamGain(_ samples: inout [Float], gain: Float) {
+        var g = gain
+        vDSP_vsmul(samples, 1, &g, &samples, 1, vDSP_Length(samples.count))
+        var lo: Float = -0.95
+        var hi: Float = 0.95
+        vDSP_vclip(samples, 1, &lo, &hi, &samples, 1, vDSP_Length(samples.count))
+    }
+
+    /// Build a 100ms silence buffer for inter-chunk gaps in the stream.
+    private static func makeInterChunkSilenceBuffer() -> AVAudioPCMBuffer? {
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: audioFormat,
+                frameCapacity: AVAudioFrameCount(interChunkSilence))
+        else { return nil }
+        buffer.frameLength = AVAudioFrameCount(interChunkSilence)
+        if let channel = buffer.floatChannelData?[0] {
+            memset(channel, 0, interChunkSilence * MemoryLayout<Float>.stride)
+        }
+        return buffer
     }
 
     // MARK: - Voices
@@ -1007,6 +1054,8 @@ public final class KokoroEngine: @unchecked Sendable {
         return AsyncStream { continuation in
             let thread = Thread {
                 let format = Self.audioFormat
+                var streamGain: Float? = nil
+                var emittedFirst = false
 
                 for tokenIds in mergedIds {
                     if Thread.current.isCancelled { break }
@@ -1019,10 +1068,19 @@ public final class KokoroEngine: @unchecked Sendable {
                             tokenIds: tokenIds, styleVector: styleVector,
                             speed: clampedSpeed)
                         Self.applyFades(&samples)
-                        Self.postProcess(&samples)
+                        Self.applyFiltering(&samples)
+                        if streamGain == nil {
+                            streamGain = Self.computeStreamGain(from: samples)
+                        }
+                        Self.applyStreamGain(&samples, gain: streamGain!)
+
+                        if emittedFirst, let silence = Self.makeInterChunkSilenceBuffer() {
+                            continuation.yield(.audio(silence))
+                        }
 
                         if let buffer = Self.makePCMBuffer(from: samples, format: format) {
                             continuation.yield(.audio(buffer))
+                            emittedFirst = true
                         }
                     } catch {
                         Self.logger.error(
@@ -1053,6 +1111,8 @@ public final class KokoroEngine: @unchecked Sendable {
         return AsyncStream { continuation in
             let thread = Thread {
                 let format = Self.audioFormat
+                var streamGain: Float? = nil
+                var emittedFirst = false
 
                 for tokenIds in mergedIds {
                     if Thread.current.isCancelled { break }
@@ -1062,10 +1122,19 @@ public final class KokoroEngine: @unchecked Sendable {
                             tokenIds: tokenIds, styleVector: styleVector,
                             speed: clampedSpeed)
                         Self.applyFades(&samples)
-                        Self.postProcess(&samples)
+                        Self.applyFiltering(&samples)
+                        if streamGain == nil {
+                            streamGain = Self.computeStreamGain(from: samples)
+                        }
+                        Self.applyStreamGain(&samples, gain: streamGain!)
+
+                        if emittedFirst, let silence = Self.makeInterChunkSilenceBuffer() {
+                            continuation.yield(.audio(silence))
+                        }
 
                         if let buffer = Self.makePCMBuffer(from: samples, format: format) {
                             continuation.yield(.audio(buffer))
+                            emittedFirst = true
                         }
                     } catch {
                         Self.logger.error(

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -429,8 +429,9 @@ public final class KokoroEngine: @unchecked Sendable {
         vDSP_vclip(samples, 1, &lo, &hi, &samples, 1, vDSP_Length(samples.count))
     }
 
-    /// Build a 100ms silence buffer for inter-chunk gaps in the stream.
-    private static func makeInterChunkSilenceBuffer() -> AVAudioPCMBuffer? {
+    /// Shared 100ms silence buffer for inter-chunk gaps. Read-only after init,
+    /// so it's safe to enqueue the same instance on the player node every call.
+    private static let interChunkSilenceBuffer: AVAudioPCMBuffer? = {
         guard
             let buffer = AVAudioPCMBuffer(
                 pcmFormat: audioFormat,
@@ -441,7 +442,7 @@ public final class KokoroEngine: @unchecked Sendable {
             memset(channel, 0, interChunkSilence * MemoryLayout<Float>.stride)
         }
         return buffer
-    }
+    }()
 
     // MARK: - Voices
 
@@ -1051,50 +1052,8 @@ public final class KokoroEngine: @unchecked Sendable {
         let (_, mergedIds) = prepareChunks(text: text)
         guard !mergedIds.isEmpty else { return AsyncStream { $0.finish() } }
 
-        return AsyncStream { continuation in
-            let thread = Thread {
-                let format = Self.audioFormat
-                var streamGain: Float? = nil
-                var emittedFirst = false
-
-                for tokenIds in mergedIds {
-                    if Thread.current.isCancelled { break }
-
-                    do {
-                        let styleVector = try self.voiceStore.embedding(
-                            for: voice, tokenCount: tokenIds.count - 2)
-
-                        var (samples, _) = try self.synthesizeChunk(
-                            tokenIds: tokenIds, styleVector: styleVector,
-                            speed: clampedSpeed)
-                        Self.applyFades(&samples)
-                        Self.applyFiltering(&samples)
-                        if streamGain == nil {
-                            streamGain = Self.computeStreamGain(from: samples)
-                        }
-                        Self.applyStreamGain(&samples, gain: streamGain!)
-
-                        if emittedFirst, let silence = Self.makeInterChunkSilenceBuffer() {
-                            continuation.yield(.audio(silence))
-                        }
-
-                        if let buffer = Self.makePCMBuffer(from: samples, format: format) {
-                            continuation.yield(.audio(buffer))
-                            emittedFirst = true
-                        }
-                    } catch {
-                        Self.logger.error(
-                            "Streaming chunk failed: \(error.localizedDescription)")
-                        continuation.yield(.chunkFailed(error))
-                    }
-                }
-
-                continuation.finish()
-            }
-            thread.stackSize = 8 * 1024 * 1024
-            nonisolated(unsafe) let unsafeThread = thread
-            continuation.onTermination = { _ in unsafeThread.cancel() }
-            thread.start()
+        return streamSpeakLoop(mergedIds: mergedIds, speed: clampedSpeed) { tokenCount in
+            try self.voiceStore.embedding(for: voice, tokenCount: tokenCount)
         }
     }
 
@@ -1108,8 +1067,21 @@ public final class KokoroEngine: @unchecked Sendable {
         let (_, mergedIds) = prepareChunks(text: text)
         guard !mergedIds.isEmpty else { return AsyncStream { $0.finish() } }
 
+        return streamSpeakLoop(mergedIds: mergedIds, speed: clampedSpeed) { _ in
+            styleVector
+        }
+    }
+
+    /// Run the per-chunk synthesis loop on a worker thread and yield
+    /// playback-ready buffers. The style-vector source is parameterized so
+    /// both `speak` overloads share this implementation.
+    private func streamSpeakLoop(
+        mergedIds: [[Int]],
+        speed: Float,
+        styleVectorFor: @escaping @Sendable (Int) throws -> [Float]
+    ) -> AsyncStream<SpeakEvent> {
         return AsyncStream { continuation in
-            let thread = Thread {
+            let thread = Thread { [self] in
                 let format = Self.audioFormat
                 var streamGain: Float? = nil
                 var emittedFirst = false
@@ -1118,17 +1090,17 @@ public final class KokoroEngine: @unchecked Sendable {
                     if Thread.current.isCancelled { break }
 
                     do {
-                        var (samples, _) = try self.synthesizeChunk(
-                            tokenIds: tokenIds, styleVector: styleVector,
-                            speed: clampedSpeed)
+                        let styleVector = try styleVectorFor(tokenIds.count - 2)
+
+                        var (samples, _) = try synthesizeChunk(
+                            tokenIds: tokenIds, styleVector: styleVector, speed: speed)
                         Self.applyFades(&samples)
                         Self.applyFiltering(&samples)
-                        if streamGain == nil {
-                            streamGain = Self.computeStreamGain(from: samples)
-                        }
-                        Self.applyStreamGain(&samples, gain: streamGain!)
+                        let gain = streamGain ?? Self.computeStreamGain(from: samples)
+                        streamGain = gain
+                        Self.applyStreamGain(&samples, gain: gain)
 
-                        if emittedFirst, let silence = Self.makeInterChunkSilenceBuffer() {
+                        if emittedFirst, let silence = Self.interChunkSilenceBuffer {
                             continuation.yield(.audio(silence))
                         }
 

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -256,19 +256,21 @@ public final class KokoroEngine: @unchecked Sendable {
         for tokenIds in mergedIds {
             totalTokens += tokenIds.count
 
-            let styleVector = try voiceStore.embedding(
-                for: voice, tokenCount: tokenIds.count - 2)
+            try autoreleasepool {
+                let styleVector = try voiceStore.embedding(
+                    for: voice, tokenCount: tokenIds.count - 2)
 
-            var (samples, durations) = try synthesizeChunk(
-                tokenIds: tokenIds, styleVector: styleVector, speed: speed)
+                var (samples, durations) = try synthesizeChunk(
+                    tokenIds: tokenIds, styleVector: styleVector, speed: speed)
 
-            Self.applyFades(&samples)
-            if !allSamples.isEmpty {
-                allSamples.append(
-                    contentsOf: [Float](repeating: 0, count: Self.interChunkSilence))
+                Self.applyFades(&samples)
+                if !allSamples.isEmpty {
+                    allSamples.append(
+                        contentsOf: [Float](repeating: 0, count: Self.interChunkSilence))
+                }
+                allSamples.append(contentsOf: samples)
+                allDurations.append(contentsOf: durations)
             }
-            allSamples.append(contentsOf: samples)
-            allDurations.append(contentsOf: durations)
         }
 
         Self.postProcess(&allSamples)
@@ -292,16 +294,18 @@ public final class KokoroEngine: @unchecked Sendable {
         for tokenIds in mergedIds {
             totalTokens += tokenIds.count
 
-            var (samples, durations) = try synthesizeChunk(
-                tokenIds: tokenIds, styleVector: styleVector, speed: speed)
+            try autoreleasepool {
+                var (samples, durations) = try synthesizeChunk(
+                    tokenIds: tokenIds, styleVector: styleVector, speed: speed)
 
-            Self.applyFades(&samples)
-            if !allSamples.isEmpty {
-                allSamples.append(
-                    contentsOf: [Float](repeating: 0, count: Self.interChunkSilence))
+                Self.applyFades(&samples)
+                if !allSamples.isEmpty {
+                    allSamples.append(
+                        contentsOf: [Float](repeating: 0, count: Self.interChunkSilence))
+                }
+                allSamples.append(contentsOf: samples)
+                allDurations.append(contentsOf: durations)
             }
-            allSamples.append(contentsOf: samples)
-            allDurations.append(contentsOf: durations)
         }
 
         Self.postProcess(&allSamples)
@@ -1089,29 +1093,34 @@ public final class KokoroEngine: @unchecked Sendable {
                 for tokenIds in mergedIds {
                     if Thread.current.isCancelled { break }
 
-                    do {
-                        let styleVector = try styleVectorFor(tokenIds.count - 2)
+                    // Drain CoreML's autoreleased MLMultiArrays/NSError/etc. between
+                    // chunks. Without this, intermediates accumulate for the entire
+                    // utterance and peak memory scales linearly with chunk count.
+                    autoreleasepool {
+                        do {
+                            let styleVector = try styleVectorFor(tokenIds.count - 2)
 
-                        var (samples, _) = try synthesizeChunk(
-                            tokenIds: tokenIds, styleVector: styleVector, speed: speed)
-                        Self.applyFades(&samples)
-                        Self.applyFiltering(&samples)
-                        let gain = streamGain ?? Self.computeStreamGain(from: samples)
-                        streamGain = gain
-                        Self.applyStreamGain(&samples, gain: gain)
+                            var (samples, _) = try synthesizeChunk(
+                                tokenIds: tokenIds, styleVector: styleVector, speed: speed)
+                            Self.applyFades(&samples)
+                            Self.applyFiltering(&samples)
+                            let gain = streamGain ?? Self.computeStreamGain(from: samples)
+                            streamGain = gain
+                            Self.applyStreamGain(&samples, gain: gain)
 
-                        if emittedFirst, let silence = Self.interChunkSilenceBuffer {
-                            continuation.yield(.audio(silence))
+                            if emittedFirst, let silence = Self.interChunkSilenceBuffer {
+                                continuation.yield(.audio(silence))
+                            }
+
+                            if let buffer = Self.makePCMBuffer(from: samples, format: format) {
+                                continuation.yield(.audio(buffer))
+                                emittedFirst = true
+                            }
+                        } catch {
+                            Self.logger.error(
+                                "Streaming chunk failed: \(error.localizedDescription)")
+                            continuation.yield(.chunkFailed(error))
                         }
-
-                        if let buffer = Self.makePCMBuffer(from: samples, format: format) {
-                            continuation.yield(.audio(buffer))
-                            emittedFirst = true
-                        }
-                    } catch {
-                        Self.logger.error(
-                            "Streaming chunk failed: \(error.localizedDescription)")
-                        continuation.yield(.chunkFailed(error))
                     }
                 }
 

--- a/Sources/KokoroCoreML/KokoroEngine.swift
+++ b/Sources/KokoroCoreML/KokoroEngine.swift
@@ -433,6 +433,12 @@ public final class KokoroEngine: @unchecked Sendable {
         vDSP_vclip(samples, 1, &lo, &hi, &samples, 1, vDSP_Length(samples.count))
     }
 
+    /// Maximum seconds of audio the producer may sit ahead of a real-time
+    /// consumer before throttling. Bounds in-flight buffers across the
+    /// AsyncStream and any player queue for long utterances where synthesis
+    /// runs faster than playback.
+    private static let producerLeadSeconds: TimeInterval = 2.0
+
     /// Shared 100ms silence buffer for inter-chunk gaps. Read-only after init,
     /// so it's safe to enqueue the same instance on the player node every call.
     private static let interChunkSilenceBuffer: AVAudioPCMBuffer? = {
@@ -1089,9 +1095,23 @@ public final class KokoroEngine: @unchecked Sendable {
                 let format = Self.audioFormat
                 var streamGain: Float? = nil
                 var emittedFirst = false
+                let streamStart = Date()
+                var audioProduced: TimeInterval = 0
 
                 for tokenIds in mergedIds {
                     if Thread.current.isCancelled { break }
+
+                    // Pace producer to within `producerLeadSeconds` of a real-time
+                    // consumer. Without this, fast synthesis on simulator/desktop
+                    // stuffs an unbounded number of AVAudioPCMBuffers into the
+                    // AsyncStream buffer and the consumer's player queue.
+                    if audioProduced > 0 {
+                        let lead = audioProduced - Date().timeIntervalSince(streamStart)
+                        if lead > Self.producerLeadSeconds {
+                            Thread.sleep(forTimeInterval: lead - Self.producerLeadSeconds)
+                            if Thread.current.isCancelled { break }
+                        }
+                    }
 
                     // Drain CoreML's autoreleased MLMultiArrays/NSError/etc. between
                     // chunks. Without this, intermediates accumulate for the entire
@@ -1110,10 +1130,14 @@ public final class KokoroEngine: @unchecked Sendable {
 
                             if emittedFirst, let silence = Self.interChunkSilenceBuffer {
                                 continuation.yield(.audio(silence))
+                                audioProduced +=
+                                    Double(silence.frameLength) / Double(Self.sampleRate)
                             }
 
                             if let buffer = Self.makePCMBuffer(from: samples, format: format) {
                                 continuation.yield(.audio(buffer))
+                                audioProduced +=
+                                    Double(buffer.frameLength) / Double(Self.sampleRate)
                                 emittedFirst = true
                             }
                         } catch {

--- a/scripts/memcheck.sh
+++ b/scripts/memcheck.sh
@@ -41,7 +41,9 @@ DEVICE_NAME="${DEVICE_NAME:-iPhone SE (3rd generation)}"
 PEAK_MB="${PEAK_MB:-4500}"
 DELTA_MB="${DELTA_MB:-4500}"
 LEAK_MB="${LEAK_MB:-150}"
-TIMEOUT_S="${TIMEOUT_S:-180}"
+# Producer paces to ~real-time, so wall time ≈ total synthesized audio
+# duration (~4 minutes for the default 3×3 suite).
+TIMEOUT_S="${TIMEOUT_S:-480}"
 XCTRACE="${XCTRACE:-0}"
 ARTIFACTS_DIR="${REPO_ROOT}/.memcheck"
 mkdir -p "$ARTIFACTS_DIR"

--- a/scripts/memcheck.sh
+++ b/scripts/memcheck.sh
@@ -29,7 +29,8 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PROJECT="${REPO_ROOT}/Examples/KokoroApp/KokoroApp.xcodeproj"
+APP_DIR="${REPO_ROOT}/Examples/KokoroApp"
+PROJECT="${APP_DIR}/KokoroApp.xcodeproj"
 SCHEME="KokoroApp"
 BUNDLE_ID="com.kokoro.app"
 
@@ -91,6 +92,16 @@ if [ "$state" != "Booted" ]; then
   log "Booting simulator..."
   xcrun simctl boot "$UDID"
   sleep 3
+fi
+
+if [ ! -d "$PROJECT" ]; then
+  log "Xcode project missing, generating from project.yml..."
+  if ! command -v xcodegen >/dev/null 2>&1; then
+    log "ERROR: xcodegen not found; install with 'brew install xcodegen' or commit a tracked project"
+    exit 3
+  fi
+  (cd "$APP_DIR" && xcodegen generate > "${ARTIFACTS_DIR}/xcodegen.log" 2>&1) \
+    || { log "ERROR: xcodegen failed — see ${ARTIFACTS_DIR}/xcodegen.log"; tail -20 "${ARTIFACTS_DIR}/xcodegen.log"; exit 3; }
 fi
 
 log "Building app..."
@@ -186,6 +197,11 @@ teardown = next((e for e in events if e["name"] == "teardown"), None)
 post_load = next((e for e in events if e["name"] == "post_engine_load"), None)
 residual = (teardown["mb"] - baseline) if teardown else None
 
+error_events = [e for e in events if e["name"] in ("error", "chunk_failed")]
+case_starts = sum(1 for e in events if e["name"] == "case_start")
+case_ends = sum(1 for e in events if e["name"] == "case_end")
+first_buffers = sum(1 for e in events if e["name"] == "first_buffer")
+
 print(f"baseline:       {baseline:7.1f} MB")
 if post_load:
     print(f"engine load:   +{post_load['mb'] - baseline:7.1f} MB  (resident after model load)")
@@ -204,6 +220,15 @@ for ev in events:
 print()
 
 failures = []
+if error_events:
+    names = ", ".join(f"{e['name']}({(e.get('detail') or '')[:60]})" for e in error_events[:5])
+    failures.append(f"runtime errors logged: {names}")
+if case_starts == 0:
+    failures.append("no synthesis cases ran")
+elif case_ends != case_starts:
+    failures.append(f"only {case_ends}/{case_starts} cases completed")
+elif first_buffers != case_starts:
+    failures.append(f"only {first_buffers}/{case_starts} cases produced audio")
 if peak > peak_budget:
     failures.append(f"peak {peak:.1f} MB > budget {peak_budget:.0f} MB")
 if delta > delta_budget:
@@ -214,7 +239,7 @@ if failures:
     print("FAIL: " + "; ".join(failures))
     sys.exit(1)
 else:
-    print("Within budget.")
+    print(f"Within budget ({case_ends}/{case_starts} cases, {first_buffers} produced audio).")
     sys.exit(0)
 PY
 then

--- a/scripts/memcheck.sh
+++ b/scripts/memcheck.sh
@@ -41,9 +41,7 @@ DEVICE_NAME="${DEVICE_NAME:-iPhone SE (3rd generation)}"
 PEAK_MB="${PEAK_MB:-4500}"
 DELTA_MB="${DELTA_MB:-4500}"
 LEAK_MB="${LEAK_MB:-150}"
-# Producer paces to ~real-time, so wall time ≈ total synthesized audio
-# duration (~4 minutes for the default 3×3 suite).
-TIMEOUT_S="${TIMEOUT_S:-480}"
+TIMEOUT_S="${TIMEOUT_S:-240}"
 XCTRACE="${XCTRACE:-0}"
 ARTIFACTS_DIR="${REPO_ROOT}/.memcheck"
 mkdir -p "$ARTIFACTS_DIR"

--- a/scripts/memcheck.sh
+++ b/scripts/memcheck.sh
@@ -4,11 +4,27 @@
 #
 # Usage:
 #   scripts/memcheck.sh                       # default thresholds + sim
-#   PEAK_MB=300 scripts/memcheck.sh           # override peak budget
+#   PEAK_MB=4500 scripts/memcheck.sh          # override peak budget
+#   LEAK_MB=120 scripts/memcheck.sh           # post-run residual budget
 #   DEVICE_NAME="iPhone 16" scripts/memcheck.sh
 #   XCTRACE=1 scripts/memcheck.sh             # also record an Allocations trace
 #
-# Exits non-zero if peak phys_footprint exceeds PEAK_MB (default 300).
+# Important: simulator memory is NOT a faithful proxy for device memory.
+# CoreML's GPU/MPS working set counts against phys_footprint differently
+# than ANE allocations on real hardware. Use this script to:
+#   1. Detect leaks: teardown footprint should return near baseline.
+#   2. Detect regressions: peak shouldn't grow run-over-run.
+#   3. Compare optimizations: same suite before/after a change.
+# For absolute "won't get jetsamed on iPhone SE", run on real hardware.
+#
+# Exit codes:
+#   0  pass
+#   1  budget exceeded
+#   2  simulator setup failed
+#   3  build failed
+#   4  built app not found
+#   5  test run timed out
+#   10 result markers not found in log
 
 set -euo pipefail
 
@@ -18,8 +34,12 @@ SCHEME="KokoroApp"
 BUNDLE_ID="com.kokoro.app"
 
 DEVICE_NAME="${DEVICE_NAME:-iPhone SE (3rd generation)}"
-PEAK_MB="${PEAK_MB:-300}"
-DELTA_MB="${DELTA_MB:-250}"
+# Simulator-realistic defaults. CoreML on simulator uses CPU/Metal, which
+# has a much larger working set than ANE on real device. These are picked
+# to flag regressions; real-device numbers are typically 10-20x lower.
+PEAK_MB="${PEAK_MB:-4500}"
+DELTA_MB="${DELTA_MB:-4500}"
+LEAK_MB="${LEAK_MB:-150}"
 TIMEOUT_S="${TIMEOUT_S:-180}"
 XCTRACE="${XCTRACE:-0}"
 ARTIFACTS_DIR="${REPO_ROOT}/.memcheck"
@@ -149,27 +169,53 @@ with open(out_path, "w") as out:
 print(out_path)
 PY
 
-if ! python3 - "$JSON_OUT" "$PEAK_MB" "$DELTA_MB" <<'PY'
+if ! python3 - "$JSON_OUT" "$PEAK_MB" "$DELTA_MB" "$LEAK_MB" <<'PY'
 import json, sys
-path, peak_budget, delta_budget = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
+path = sys.argv[1]
+peak_budget = float(sys.argv[2])
+delta_budget = float(sys.argv[3])
+leak_budget = float(sys.argv[4])
 data = json.load(open(path))
 peak = data["peakMB"]
 delta = data["peakDeltaMB"]
 baseline = data["baselineMB"]
 duration = data["durationSeconds"]
-print(f"baseline:    {baseline:7.1f} MB")
-print(f"peak:        {peak:7.1f} MB  (budget {peak_budget:.0f} MB)")
-print(f"peak delta:  {delta:7.1f} MB  (budget {delta_budget:.0f} MB)")
-print(f"duration:    {duration:7.1f} s")
-print(f"events:      {len(data['events'])}")
-print(f"samples:     {len(data['samples'])}")
+events = data["events"]
+
+teardown = next((e for e in events if e["name"] == "teardown"), None)
+post_load = next((e for e in events if e["name"] == "post_engine_load"), None)
+residual = (teardown["mb"] - baseline) if teardown else None
+
+print(f"baseline:       {baseline:7.1f} MB")
+if post_load:
+    print(f"engine load:   +{post_load['mb'] - baseline:7.1f} MB  (resident after model load)")
+print(f"peak:           {peak:7.1f} MB  (budget {peak_budget:.0f} MB)")
+print(f"peak delta:    +{delta:7.1f} MB  (budget {delta_budget:.0f} MB)")
+if teardown:
+    print(f"residual:      +{residual:7.1f} MB  (budget {leak_budget:.0f} MB) — should be near 0")
+print(f"duration:       {duration:7.1f} s")
+print(f"events:         {len(events)}")
+print(f"samples:        {len(data['samples'])}")
 print()
 print("Lifecycle events (mb):")
-for ev in data["events"]:
+for ev in events:
     detail = f"  [{ev['detail']}]" if ev.get("detail") else ""
     print(f"  {ev['timeSeconds']:6.2f}s  {ev['name']:24s} {ev['mb']:7.1f}{detail}")
-ok = peak <= peak_budget and delta <= delta_budget
-sys.exit(0 if ok else 1)
+print()
+
+failures = []
+if peak > peak_budget:
+    failures.append(f"peak {peak:.1f} MB > budget {peak_budget:.0f} MB")
+if delta > delta_budget:
+    failures.append(f"peak delta {delta:.1f} MB > budget {delta_budget:.0f} MB")
+if teardown and residual > leak_budget:
+    failures.append(f"residual {residual:.1f} MB > leak budget {leak_budget:.0f} MB (possible leak)")
+if failures:
+    print("FAIL: " + "; ".join(failures))
+    sys.exit(1)
+else:
+    print("Within budget.")
+    sys.exit(0)
 PY
 then
   log "FAIL: memory budget exceeded"

--- a/scripts/memcheck.sh
+++ b/scripts/memcheck.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Build the example app for an iPhone SE simulator, run the deterministic
+# --memory-test suite, and assert that phys_footprint stays within budget.
+#
+# Usage:
+#   scripts/memcheck.sh                       # default thresholds + sim
+#   PEAK_MB=300 scripts/memcheck.sh           # override peak budget
+#   DEVICE_NAME="iPhone 16" scripts/memcheck.sh
+#   XCTRACE=1 scripts/memcheck.sh             # also record an Allocations trace
+#
+# Exits non-zero if peak phys_footprint exceeds PEAK_MB (default 300).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="${REPO_ROOT}/Examples/KokoroApp/KokoroApp.xcodeproj"
+SCHEME="KokoroApp"
+BUNDLE_ID="com.kokoro.app"
+
+DEVICE_NAME="${DEVICE_NAME:-iPhone SE (3rd generation)}"
+PEAK_MB="${PEAK_MB:-300}"
+DELTA_MB="${DELTA_MB:-250}"
+TIMEOUT_S="${TIMEOUT_S:-180}"
+XCTRACE="${XCTRACE:-0}"
+ARTIFACTS_DIR="${REPO_ROOT}/.memcheck"
+mkdir -p "$ARTIFACTS_DIR"
+
+log() { echo "[memcheck] $*"; }
+
+resolve_device() {
+  local name="$1"
+  xcrun simctl list devices available --json \
+    | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+target=sys.argv[1]
+for runtime, devs in data['devices'].items():
+    for d in devs:
+        if d['name']==target and d['isAvailable']:
+            print(d['udid']); sys.exit(0)
+sys.exit(1)
+" "$name" 2>/dev/null
+}
+
+UDID="$(resolve_device "$DEVICE_NAME" || true)"
+if [ -z "$UDID" ]; then
+  log "Simulator \"$DEVICE_NAME\" not found, attempting to create it..."
+  DEVICE_TYPE_ID="$(xcrun simctl list devicetypes | grep -F "$DEVICE_NAME" | grep -oE 'com\.apple\.CoreSimulator\.SimDeviceType\.[A-Za-z0-9-]+' | head -1)"
+  RUNTIME_ID="$(xcrun simctl list runtimes | grep -E '^iOS' | grep -oE 'com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+' | tail -1)"
+  if [ -z "$DEVICE_TYPE_ID" ] || [ -z "$RUNTIME_ID" ]; then
+    log "ERROR: cannot create — device type \"$DEVICE_NAME\" or iOS runtime not found"
+    log "Available device types matching SE/iPhone:"
+    xcrun simctl list devicetypes | grep -iE "iPhone SE|iPhone 1[6-9]|iPhone Air" | sed 's/^/  /'
+    exit 2
+  fi
+  UDID="$(xcrun simctl create "$DEVICE_NAME" "$DEVICE_TYPE_ID" "$RUNTIME_ID")"
+  log "Created $DEVICE_NAME ($UDID) on $RUNTIME_ID"
+fi
+log "Device: $DEVICE_NAME ($UDID)"
+
+state="$(xcrun simctl list devices --json | python3 -c "
+import json,sys
+data=json.load(sys.stdin)
+udid=sys.argv[1]
+for runtime, devs in data['devices'].items():
+    for d in devs:
+        if d['udid']==udid:
+            print(d['state']); sys.exit(0)
+" "$UDID")"
+if [ "$state" != "Booted" ]; then
+  log "Booting simulator..."
+  xcrun simctl boot "$UDID"
+  sleep 3
+fi
+
+log "Building app..."
+DERIVED="${ARTIFACTS_DIR}/DerivedData"
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=$UDID" \
+  -derivedDataPath "$DERIVED" \
+  -quiet \
+  build > "${ARTIFACTS_DIR}/build.log" 2>&1 \
+  || { log "ERROR: build failed — see ${ARTIFACTS_DIR}/build.log"; tail -30 "${ARTIFACTS_DIR}/build.log"; exit 3; }
+
+APP_PATH="$(find "$DERIVED/Build/Products" -name "${SCHEME}.app" -type d -maxdepth 4 | head -1)"
+if [ -z "$APP_PATH" ]; then
+  log "ERROR: built app not found under $DERIVED/Build/Products"
+  exit 4
+fi
+log "App: $APP_PATH"
+
+log "Installing..."
+xcrun simctl install "$UDID" "$APP_PATH"
+
+LOG_FILE="${ARTIFACTS_DIR}/run.log"
+rm -f "$LOG_FILE"
+
+log "Running --memory-test (timeout ${TIMEOUT_S}s)..."
+(
+  xcrun simctl launch --console-pty --terminate-running-process \
+    "$UDID" "$BUNDLE_ID" --memory-test \
+    > "$LOG_FILE" 2>&1
+) &
+LAUNCH_PID=$!
+
+SECONDS_WAITED=0
+while kill -0 "$LAUNCH_PID" 2>/dev/null; do
+  if [ "$SECONDS_WAITED" -ge "$TIMEOUT_S" ]; then
+    log "ERROR: timeout, terminating app"
+    xcrun simctl terminate "$UDID" "$BUNDLE_ID" 2>/dev/null || true
+    kill "$LAUNCH_PID" 2>/dev/null || true
+    exit 5
+  fi
+  sleep 1
+  SECONDS_WAITED=$((SECONDS_WAITED + 1))
+done
+
+if [ "$XCTRACE" = "1" ]; then
+  TRACE_OUT="${ARTIFACTS_DIR}/allocations.trace"
+  rm -rf "$TRACE_OUT"
+  log "Recording xctrace Allocations (this is slow)..."
+  xcrun xctrace record \
+    --template "Allocations" \
+    --device "$UDID" \
+    --output "$TRACE_OUT" \
+    --launch -- "$APP_PATH/${SCHEME}" --memory-test \
+    --time-limit "${TIMEOUT_S}s" \
+    > "${ARTIFACTS_DIR}/xctrace.log" 2>&1 \
+    || log "WARN: xctrace returned non-zero — see ${ARTIFACTS_DIR}/xctrace.log"
+  log "Trace: $TRACE_OUT (open in Instruments.app)"
+fi
+
+JSON_OUT="${ARTIFACTS_DIR}/result.json"
+python3 - "$LOG_FILE" "$JSON_OUT" <<'PY'
+import sys, re
+log_path, out_path = sys.argv[1], sys.argv[2]
+with open(log_path, "r", errors="replace") as f:
+    text = f.read()
+m = re.search(r"MEMORY_TEST_RESULT_START\s*\n(.*?)\nMEMORY_TEST_RESULT_END", text, re.S)
+if not m:
+    sys.stderr.write("no result markers found in log\n")
+    sys.stderr.write(text[-2000:])
+    sys.exit(10)
+with open(out_path, "w") as out:
+    out.write(m.group(1))
+print(out_path)
+PY
+
+if ! python3 - "$JSON_OUT" "$PEAK_MB" "$DELTA_MB" <<'PY'
+import json, sys
+path, peak_budget, delta_budget = sys.argv[1], float(sys.argv[2]), float(sys.argv[3])
+data = json.load(open(path))
+peak = data["peakMB"]
+delta = data["peakDeltaMB"]
+baseline = data["baselineMB"]
+duration = data["durationSeconds"]
+print(f"baseline:    {baseline:7.1f} MB")
+print(f"peak:        {peak:7.1f} MB  (budget {peak_budget:.0f} MB)")
+print(f"peak delta:  {delta:7.1f} MB  (budget {delta_budget:.0f} MB)")
+print(f"duration:    {duration:7.1f} s")
+print(f"events:      {len(data['events'])}")
+print(f"samples:     {len(data['samples'])}")
+print()
+print("Lifecycle events (mb):")
+for ev in data["events"]:
+    detail = f"  [{ev['detail']}]" if ev.get("detail") else ""
+    print(f"  {ev['timeSeconds']:6.2f}s  {ev['name']:24s} {ev['mb']:7.1f}{detail}")
+ok = peak <= peak_budget and delta <= delta_budget
+sys.exit(0 if ok else 1)
+PY
+then
+  log "FAIL: memory budget exceeded"
+  exit 1
+fi
+
+log "PASS"


### PR DESCRIPTION
## Summary

Bundles three previously-merged-elsewhere streams of memory work into a single PR against `main`. Targets [#11](https://github.com/Jud/kokoro-coreml/issues/11) (iPhone SE jetsam) by removing per-utterance buffer accumulation and giving us a CLI memcheck harness for future regressions. **No model re-export required** — pure Swift + scripts.

### What's in the box (17 commits)

**Streaming `speak()`** — Per-chunk peak normalization replaced with a fixed gain locked from the first chunk (allows attenuation, peak-rescales overshooting chunks instead of hard-clipping). 100 ms inter-chunk silence buffers allocated fresh per gap (no shared mutable singleton on the public API). Producer paces to within 2 s of a real-time consumer using `CFAbsoluteTimeGetCurrent`, sleeping in 50 ms increments so `onTermination` tears the worker down promptly. New `paceToRealtime: Bool = true` parameter on `speak()` lets batch consumers (file export, tests) opt out.

**KokoroApp playback** — `AudioEngine` rewritten around an `AsyncStream<SpeakEvent>` with a generation counter for race-safe `start()`/`stop()`. Tap installed at 24 kHz on the player node (was incorrectly at 48 kHz via `mainMixerNode`).

**autoreleasepool drain** — Each chunk iteration in `streamSpeakLoop`/`synthesizeTokens`/`synthesizeTokensWithEmbedding` wraps in `autoreleasepool` so CoreML's autoreleased `MLMultiArray`/`MLFeatureProvider`/`NSError` instances don't accumulate for the duration of the utterance. Cuts simulator per-suite duration ~17%.

**CLI memcheck harness** — `scripts/memcheck.sh` boots an iPhone SE (3rd gen) simulator, builds and installs the app, runs a deterministic 3-voice × 3-length suite while sampling `phys_footprint` at 10 Hz, parses the fenced JSON dump, and asserts peak/delta/residual budgets and case-completion counts. Catches both leaks (post-teardown residual) and regressions (peak run-over-run). Documented that simulator memory is NOT a faithful jetsam proxy — use for relative comparison, not absolute thresholds.

### Review chain

Every unit went through audit → optional codex → comment cleanup → chunk-close simplify + codex. Notable findings caught and fixed:
- Stale `.dataPlayedBack` callbacks decrementing a generation-stale counter (audit).
- Consumer-side player-queue cap caused underruns when a single chunk exceeded the 2 s cap — removed in favor of producer-only pacing (chunk-close codex).
- `Thread.sleep` ignored cancellation — replaced with 50 ms-incremented polling (chunk-close codex).
- Magic numbers (0.95, 0.001, 0.99) extracted to named constants so streaming and batch paths share one source of truth (chunk-close simplify).

### What this PR does *not* do

- No iOS Simulator memory drop (peak is structural MPSGraph working set, ~4 GB on sim). Real-device numbers are typically 10-20× lower; this PR's leak-and-residual checks pass on the simulator, but the absolute peak budget validation needs real hardware.
- No model export changes. Hybrid 4-bit/8-bit palettization and lazy voice packs (~24 MB resident win) remain queued for a separate PR.
- No `forceCPU: true` improvements — that path needs profiling on real hardware to identify the dominant memory consumer before any code or export changes.

## Test plan

- [ ] `swift build` — green locally.
- [ ] `scripts/memcheck.sh` on iPhone SE (3rd gen) simulator — peak/delta/residual within budgets, all 9 cases complete with audio.
- [ ] CLI streaming: `kokoro say --stream "<long text>" --voice af_heart` — listen for chunk-boundary stutter (should be unchanged), no producer-side runaway.
- [ ] KokoroApp on real device — start/stop several times mid-utterance, verify clean teardown and no leaked audio session.
- [ ] **Outstanding**: real-device iPhone SE memory measurement to validate the issue #11 closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)